### PR TITLE
add namespace filter

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -20,7 +20,8 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.1.2",
-    "sunflower-antd": "^1.0.0-beta.3"
+    "sunflower-antd": "^1.0.0-beta.3",
+    "usehooks-ts": "^2.9.1"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/packages/refine/src/components/Layout/index.tsx
+++ b/packages/refine/src/components/Layout/index.tsx
@@ -3,6 +3,7 @@ import { css, cx } from '@linaria/core';
 import { PropsWithChildren, useState } from 'react';
 import React from 'react';
 import { Menu } from '../Menu';
+import { NamespacesFilter } from '../NamespacesFilter';
 
 const HeaderStyle = css`
   &.ant-layout-header {
@@ -44,16 +45,23 @@ export const Layout: React.FC<PropsWithChildren<Record<string, unknown>>> = ({
 
   return (
     <kit.layout style={{ height: '100%' }}>
-      <Header className={cx(HeaderStyle, Typo.Heading.h1_bold_title)} >
+      <Header className={cx(HeaderStyle, Typo.Heading.h1_bold_title)}>
         Dovetail 2
+        <div style={{ width: 300 }}>
+          <NamespacesFilter />
+        </div>
       </Header>
       <kit.layout className={ContentLayoutStyle}>
-        <Sider width={256} className={SiderStyle} theme="light" collapsed={collapsed} onCollapse={(value) => setCollapsed(value)}>
+        <Sider
+          width={256}
+          className={SiderStyle}
+          theme="light"
+          collapsed={collapsed}
+          onCollapse={value => setCollapsed(value)}
+        >
           <Menu />
         </Sider>
-        <Content className={ContentStyle}>
-          {children}
-        </Content>
+        <Content className={ContentStyle}>{children}</Content>
       </kit.layout>
     </kit.layout>
   );

--- a/packages/refine/src/components/NamespacesFilter/index.tsx
+++ b/packages/refine/src/components/NamespacesFilter/index.tsx
@@ -1,10 +1,19 @@
 import { useUIKit } from '@cloudtower/eagle';
-import { useGo, useList, useParsed } from '@refinedev/core';
+import { useList } from '@refinedev/core';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocalStorage } from 'usehooks-ts';
 
 export const NS_STORE_KEY = 'namespace-filter';
 export const ALL_NS = '_all';
+
+export const useNamespacesFilter = () => {
+  const [value] = useLocalStorage(NS_STORE_KEY, ALL_NS);
+
+  return {
+    value,
+  };
+};
 
 export const NamespacesFilter: React.FC = () => {
   const kit = useUIKit();
@@ -17,23 +26,14 @@ export const NamespacesFilter: React.FC = () => {
     },
   });
 
-  const parsed = useParsed();
-  const go = useGo();
-  const value = parsed.params?.[NS_STORE_KEY] || ALL_NS;
+  const [value, setValue] = useLocalStorage(NS_STORE_KEY, ALL_NS);
 
   return (
     <kit.select
       input={{
         value,
         onChange(value) {
-          go({
-            query: {
-              [NS_STORE_KEY]: value,
-            },
-            options: {
-              keepQuery: true,
-            },
-          });
+          setValue(value as string);
         },
       }}
     >

--- a/packages/refine/src/components/NamespacesFilter/index.tsx
+++ b/packages/refine/src/components/NamespacesFilter/index.tsx
@@ -1,0 +1,53 @@
+import { useUIKit } from '@cloudtower/eagle';
+import { useGo, useList, useParsed } from '@refinedev/core';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export const NS_STORE_KEY = 'namespace-filter';
+export const ALL_NS = '_all';
+
+export const NamespacesFilter: React.FC = () => {
+  const kit = useUIKit();
+  const { t } = useTranslation();
+  const { data } = useList({
+    resource: 'namespaces',
+    meta: {
+      resourceBasePath: '/api/v1',
+      kind: 'Namespace',
+    },
+  });
+
+  const parsed = useParsed();
+  const go = useGo();
+  const value = parsed.params?.[NS_STORE_KEY] || ALL_NS;
+
+  return (
+    <kit.select
+      input={{
+        value,
+        onChange(value) {
+          go({
+            query: {
+              [NS_STORE_KEY]: value,
+            },
+            options: {
+              keepQuery: true,
+            },
+          });
+        },
+      }}
+    >
+      <kit.option key="_all" value="_all">
+        {t('dovetail.all_namespaces')}
+      </kit.option>
+      {data?.data.map(namespace => {
+        const { name } = namespace.metadata;
+        return (
+          <kit.option key={name} value={name}>
+            {name}
+          </kit.option>
+        );
+      })}
+    </kit.select>
+  );
+};

--- a/packages/refine/src/hooks/useEagleTable/index.tsx
+++ b/packages/refine/src/hooks/useEagleTable/index.tsx
@@ -1,13 +1,12 @@
 import { SettingsGear16GradientGrayIcon } from '@cloudtower/icons-react';
-import { useParsed, useTable } from '@refinedev/core';
-import { useCallback, useMemo, useState } from 'react';
+import { useTable } from '@refinedev/core';
 import { merge } from 'lodash-es';
-import React from 'react';
-import K8sDropdown from 'src/components/K8sDropdown';
+import React, { useCallback, useMemo, useState } from 'react';
+import K8sDropdown from '../../components/K8sDropdown';
+import { useNamespacesFilter, ALL_NS } from '../../components/NamespacesFilter';
 import { Column, TableProps } from '../../components/Table';
 import { ResourceModel } from '../../model';
 import { Resource } from '../../types';
-import { ALL_NS, NS_STORE_KEY } from 'src/components/NamespacesFilter';
 
 type Params<Raw extends Resource, Model extends ResourceModel> = {
   useTableParams: Parameters<typeof useTable<Raw>>[0];
@@ -33,8 +32,7 @@ export const useEagleTable = <Raw extends Resource, Model extends ResourceModel>
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
   const [currentPage, setCurrentPage] = useState(tableProps?.currentPage || 1);
 
-  const parsed = useParsed();
-  const nsFilter = parsed.params?.['namespace-filter'] || ALL_NS;
+  const { value: nsFilter } = useNamespacesFilter();
 
   const useTableParams = useMemo(() => {
     // TODO: check whether resource can be namespaced

--- a/packages/refine/src/locales/zh-CN/dovetail.json
+++ b/packages/refine/src/locales/zh-CN/dovetail.json
@@ -34,5 +34,6 @@
   "message": "消息",
   "save": "保存",
   "more": "更多",
-  "workload": "工作负载"
+  "workload": "工作负载",
+  "all_namespaces": "所有名字空间"
 }

--- a/packages/refine/src/pages/configmap/list/index.tsx
+++ b/packages/refine/src/pages/configmap/list/index.tsx
@@ -22,7 +22,7 @@ export const ConfigmapList: React.FC<IResourceComponentsProps> = <
   const { i18n } = useTranslation();
 
   const { tableProps, selectedKeys } = useEagleTable<T>({
-    useTableParams: [{ syncWithLocation: true }],
+    useTableParams: { syncWithLocation: true },
     columns: [
       NameColumnRenderer(i18n),
       NameSpaceColumnRenderer(i18n),

--- a/packages/refine/src/pages/cronjobs/list/index.tsx
+++ b/packages/refine/src/pages/cronjobs/list/index.tsx
@@ -32,7 +32,7 @@ const TableStyle = css`
 export const CronJobList: React.FC<IResourceComponentsProps> = () => {
   const { i18n } = useTranslation();
   const { tableProps, selectedKeys } = useEagleTable<WithId<CronJob>, WorkloadModel>({
-    useTableParams: [{}],
+    useTableParams: {},
     columns: [
       PhaseColumnRenderer(i18n),
       NameColumnRenderer(i18n),

--- a/packages/refine/src/pages/daemonsets/list/index.tsx
+++ b/packages/refine/src/pages/daemonsets/list/index.tsx
@@ -31,7 +31,7 @@ const TableStyle = css`
 export const DaemonSetList: React.FC<IResourceComponentsProps> = () => {
   const { i18n } = useTranslation();
   const { tableProps, selectedKeys } = useEagleTable<WithId<DaemonSet>, WorkloadModel>({
-    useTableParams: [{}],
+    useTableParams: {},
     columns: [
       PhaseColumnRenderer(i18n),
       NameColumnRenderer(i18n),

--- a/packages/refine/src/pages/deployments/list/index.tsx
+++ b/packages/refine/src/pages/deployments/list/index.tsx
@@ -31,8 +31,9 @@ const TableStyle = css`
 
 export const DeploymentList: React.FC<IResourceComponentsProps> = () => {
   const { i18n } = useTranslation();
+
   const { tableProps, selectedKeys } = useEagleTable<WithId<Deployment>, WorkloadModel>({
-    useTableParams: [{}],
+    useTableParams: {},
     columns: [
       PhaseColumnRenderer(i18n),
       NameColumnRenderer(i18n),

--- a/packages/refine/src/pages/jobs/list/index.tsx
+++ b/packages/refine/src/pages/jobs/list/index.tsx
@@ -31,7 +31,7 @@ const TableStyle = css`
 export const JobList: React.FC<IResourceComponentsProps> = () => {
   const { i18n } = useTranslation();
   const { tableProps, selectedKeys } = useEagleTable<WithId<Job>, JobModel>({
-    useTableParams: [{}],
+    useTableParams: {},
     columns: [
       PhaseColumnRenderer(i18n),
       NameColumnRenderer(i18n),

--- a/packages/refine/src/pages/statefulSets/list/index.tsx
+++ b/packages/refine/src/pages/statefulSets/list/index.tsx
@@ -32,7 +32,7 @@ const TableStyle = css`
 export const StatefulSetList: React.FC<IResourceComponentsProps> = () => {
   const { i18n } = useTranslation();
   const { tableProps, selectedKeys } = useEagleTable<WithId<StatefulSet>, WorkloadModel>({
-    useTableParams: [{}],
+    useTableParams: {},
     columns: [
       PhaseColumnRenderer(i18n),
       NameColumnRenderer(i18n),

--- a/yarn.lock
+++ b/yarn.lock
@@ -9471,6 +9471,11 @@ use@^3.1.0:
   resolved "https://registry.npmmirror.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
+usehooks-ts@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz#953d3284851ffd097432379e271ce046a8180b37"
+  integrity sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==
+
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.npmmirror.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"


### PR DESCRIPTION
对比之后暂时使用 localStorage 存储 filter 信息，更容易实现路由变化、页面重新打开时的 filter 保留。

对 filter 的读写逻辑封装在了 NamespaceFilter 内部，未来可以配置为后端 API 实现。