### PR TITLE
impl workload redeploy action

### DIFF
--- a/packages/refine/src/components/PageShow/PageShow.tsx
+++ b/packages/refine/src/components/PageShow/PageShow.tsx
@@ -8,6 +8,7 @@ import { ShowContent, ShowField } from '../ShowContent';
 type Props<Raw extends Resource, Model extends ResourceModel> = {
   fieldGroups: ShowField<Model>[][];
   formatter: (r: Raw) => Model;
+  Dropdown?: React.FC<{ data: Model }>;
 };
 export const PageShow = <Raw extends Resource, Model extends ResourceModel>(
   props: Props<Raw, Model>

--- a/packages/refine/src/components/ShowContent/ShowContent.tsx
+++ b/packages/refine/src/components/ShowContent/ShowContent.tsx
@@ -34,6 +34,7 @@ const EditorStyle = css`
 type Props<Raw extends Resource, Model extends ResourceModel> = {
   fieldGroups: ShowField<Model>[][];
   formatter: (r: Raw) => Model;
+  Dropdown?: React.FC<{ data: Model }>;
 };
 
 enum Mode {
@@ -44,7 +45,7 @@ enum Mode {
 export const ShowContent = <Raw extends Resource, Model extends ResourceModel>(
   props: Props<Raw, Model>
 ) => {
-  const { fieldGroups, formatter } = props;
+  const { fieldGroups, formatter, Dropdown = K8sDropdown } = props;
   const kit = useUIKit();
   const parsed = useParsed();
   const { resource } = useResource();
@@ -131,7 +132,7 @@ export const ShowContent = <Raw extends Resource, Model extends ResourceModel>(
           <kit.radioButton value="detail">{t('detail')}</kit.radioButton>
           <kit.radioButton value="yaml">YAML</kit.radioButton>
         </kit.radioGroup>
-        <K8sDropdown data={record} />
+        <Dropdown data={record} />
       </kit.space>
     </kit.space>
   );

--- a/packages/refine/src/components/WorkloadDropdown/index.tsx
+++ b/packages/refine/src/components/WorkloadDropdown/index.tsx
@@ -1,0 +1,34 @@
+import { Icon, useUIKit } from '@cloudtower/eagle';
+import { DynamicResourceSchedule16BlueIcon } from '@cloudtower/icons-react';
+import { useResource, useUpdate } from '@refinedev/core';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { WorkloadModel } from '../../model';
+import { pruneBeforeEdit } from '../../utils/k8s';
+import K8sDropdown from '../K8sDropdown';
+
+export const WorkloadDropdown: React.FC<{ data: WorkloadModel }> = ({ data }) => {
+  const kit = useUIKit();
+  const { resource } = useResource();
+  const { mutate } = useUpdate();
+  const { t } = useTranslation();
+
+  return (
+    <K8sDropdown data={data}>
+      <kit.menu.Item
+        onClick={() => {
+          const v = data.redeploy();
+          const id = v.id;
+          pruneBeforeEdit(v);
+          mutate({
+            id,
+            resource: resource?.name || '',
+            values: v,
+          });
+        }}
+      >
+        <Icon src={DynamicResourceSchedule16BlueIcon}>{t('dovetail.redeploy')}</Icon>
+      </kit.menu.Item>
+    </K8sDropdown>
+  );
+};

--- a/packages/refine/src/constants/k8s.ts
+++ b/packages/refine/src/constants/k8s.ts
@@ -153,3 +153,5 @@ export const POD_INIT_VALUE = {
     containers: [BASE_CONTAINER_INIT_VALUE],
   },
 };
+
+export const TIMESTAMP_LABEL = 'sks.user.kubesmart.smtx.io/timestamp';

--- a/packages/refine/src/hooks/useEagleForm.ts
+++ b/packages/refine/src/hooks/useEagleForm.ts
@@ -19,6 +19,7 @@ import React, { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { type YamlEditorHandle } from 'src/components/YamlEditor';
 import { useSchema } from 'src/hooks/useSchema';
+import { pruneBeforeEdit } from 'src/utils/k8s';
 import { generateYamlBySchema } from 'src/utils/yaml';
 import { useForm as useFormSF } from 'sunflower-antd';
 
@@ -260,13 +261,7 @@ const useEagleForm = <
     : undefined;
 
   if (initialValues) {
-    delete initialValues.id;
-    delete initialValues.metadata.managedFields;
-    if (initialValues.metadata.annotations) {
-      delete initialValues.metadata.annotations[
-        'kubectl.kubernetes.io/last-applied-configuration'
-      ];
-    }
+    pruneBeforeEdit(initialValues);
   }
 
   return {

--- a/packages/refine/src/hooks/useEagleTable/index.tsx
+++ b/packages/refine/src/hooks/useEagleTable/index.tsx
@@ -13,6 +13,7 @@ type Params<Raw extends Resource, Model extends ResourceModel> = {
   columns: Column<Model>[];
   tableProps?: Partial<TableProps<Model>>;
   formatter: (d: Raw) => Model;
+  Dropdown?: React.FC<{ data: Model }>;
 };
 
 export enum ColumnKeys {
@@ -28,7 +29,7 @@ export enum ColumnKeys {
 export const useEagleTable = <Raw extends Resource, Model extends ResourceModel>(
   params: Params<Raw, Model>
 ) => {
-  const { columns, tableProps, formatter } = params;
+  const { columns, tableProps, formatter, Dropdown = K8sDropdown } = params;
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
   const [currentPage, setCurrentPage] = useState(tableProps?.currentPage || 1);
 
@@ -36,20 +37,17 @@ export const useEagleTable = <Raw extends Resource, Model extends ResourceModel>
 
   const useTableParams = useMemo(() => {
     // TODO: check whether resource can be namespaced
-    const mergedParams = merge(
-      params.useTableParams,
-      {
-        filters: {
-          permanent: [
-            {
-              field: 'metadata.namespace',
-              operator: 'eq',
-              value: nsFilter === ALL_NS ? null : nsFilter,
-            },
-          ],
-        },
-      }
-    );
+    const mergedParams = merge(params.useTableParams, {
+      filters: {
+        permanent: [
+          {
+            field: 'metadata.namespace',
+            operator: 'eq',
+            value: nsFilter === ALL_NS ? null : nsFilter,
+          },
+        ],
+      },
+    });
     return mergedParams;
   }, [params.useTableParams, nsFilter]);
 
@@ -68,7 +66,7 @@ export const useEagleTable = <Raw extends Resource, Model extends ResourceModel>
     dataIndex: [],
     title: () => <SettingsGear16GradientGrayIcon />,
     render: (_: unknown, record: Model) => {
-      return <K8sDropdown data={record} />;
+      return <Dropdown data={record} />;
     },
   };
 

--- a/packages/refine/src/locales/zh-CN/dovetail.json
+++ b/packages/refine/src/locales/zh-CN/dovetail.json
@@ -44,5 +44,6 @@
   "started": "开始时间",
   "ready": "就绪",
   "init_container": "初始化容器",
-  "container": "容器"
+  "container": "容器",
+  "redeploy": "重新部署"
 }

--- a/packages/refine/src/model/workload-model.ts
+++ b/packages/refine/src/model/workload-model.ts
@@ -1,13 +1,15 @@
 import type { DaemonSet, Deployment, StatefulSet } from 'kubernetes-types/apps/v1';
 import type { CronJob, Job } from 'kubernetes-types/batch/v1';
 import { Pod } from 'kubernetes-types/core/v1';
+import { set, get, cloneDeep } from 'lodash-es';
+import { TIMESTAMP_LABEL } from '../constants/k8s';
 import { WithId } from '../types';
 import { shortenedImage } from '../utils/string';
 import { ResourceModel } from './resource-model';
 
 type WorkloadTypes = Deployment | StatefulSet | Job | DaemonSet | CronJob | Pod;
 export class WorkloadModel<
-  T extends WorkloadTypes = WorkloadTypes
+  T extends WorkloadTypes = WorkloadTypes,
 > extends ResourceModel {
   constructor(public data: WithId<T>) {
     super(data);
@@ -36,5 +38,16 @@ export class WorkloadModel<
   get restartCount() {
     // TODO: need count from pods
     return 0;
+  }
+
+  redeploy() {
+    const newOne = cloneDeep(this.data);
+    const path = 'spec.template.metadata.annotations';
+    const annotations = get(newOne, path, {});
+    set(newOne, path, {
+      ...annotations,
+      [TIMESTAMP_LABEL]: new Date().toISOString().replace(/\.\d+Z$/, 'Z'),
+    });
+    return newOne;
   }
 }

--- a/packages/refine/src/pages/deployments/list/index.tsx
+++ b/packages/refine/src/pages/deployments/list/index.tsx
@@ -3,6 +3,7 @@ import { Deployment } from 'kubernetes-types/apps/v1';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import ListPage from 'src/components/ListPage';
+import { WorkloadDropdown } from 'src/components/WorkloadDropdown';
 import { useEagleTable } from 'src/hooks/useEagleTable';
 import {
   AgeColumnRenderer,
@@ -32,6 +33,7 @@ export const DeploymentList: React.FC<IResourceComponentsProps> = () => {
       currentSize: 10,
     },
     formatter: d => new WorkloadModel(d),
+    Dropdown: WorkloadDropdown,
   });
 
   return (

--- a/packages/refine/src/pages/deployments/show/index.tsx
+++ b/packages/refine/src/pages/deployments/show/index.tsx
@@ -9,6 +9,7 @@ import {
   PodsField,
   ReplicaField,
 } from '../../../components/ShowContent/fields';
+import { WorkloadDropdown } from '../../../components/WorkloadDropdown';
 import { WorkloadModel } from '../../../model';
 import { WithId } from '../../../types';
 
@@ -23,6 +24,7 @@ export const DeploymentShow: React.FC<IResourceComponentsProps> = () => {
         [PodsField(i18n), ConditionsField(i18n)],
       ]}
       formatter={d => new WorkloadModel(d)}
+      Dropdown={WorkloadDropdown}
     />
   );
 };

--- a/packages/refine/src/utils/k8s.ts
+++ b/packages/refine/src/utils/k8s.ts
@@ -1,3 +1,13 @@
+import { BaseRecord } from '@refinedev/core';
+
 export function getApiVersion(resourceBasePath: string): string {
   return resourceBasePath.replace(/^(\/api\/)|(\/apis\/)/, '');
+}
+
+export function pruneBeforeEdit(v: BaseRecord) {
+  delete v.id;
+  delete v.metadata?.managedFields;
+  if (v.metadata?.annotations) {
+    delete v.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration'];
+  }
 }


### PR DESCRIPTION
1. 在 workload model 中增加了 redeploy 方法，用于构造一个用于重新部署的 yaml，实际上是通过更新 annotation 触发重建
2. 扩展 list 和 show 页面，支持传入 Dropdown props，不传入则使用默认的 K8sDropdown
3. 实现 WorkloadDropdown，扩展 K8sDropdown，增加 redeploy 入口