### PR TITLE
feat: add schema strategy for editor

### DIFF
--- a/packages/refine/src/components/ErrorContent/index.tsx
+++ b/packages/refine/src/components/ErrorContent/index.tsx
@@ -1,0 +1,65 @@
+import { kitContext, Typo } from '@cloudtower/eagle';
+import { cx } from '@linaria/core';
+import { styled } from '@linaria/react';
+import React, { useContext } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export const ErrorWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+`;
+
+export const ErrorContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .title {
+    margin-bottom: 8px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-image: linear-gradient(211.41deg, #929dad 0%, #d3dbe3 100%);
+  }
+`;
+
+export type WidgetErrorContentProps = {
+  className?: string;
+  style?: React.CSSProperties;
+  errorText?: string;
+  hiddenRetry?: boolean;
+  refetch?: () => void;
+};
+
+const WidgetErrorContent: React.FunctionComponent<WidgetErrorContentProps> = props => {
+  const { refetch, errorText, hiddenRetry } = props;
+  const kit = useContext(kitContext);
+  const { t } = useTranslation();
+
+  return (
+    <ErrorWrapper className={props.className} style={props.style}>
+      <ErrorContent>
+        <p className={cx(Typo.Label.l1_regular_title, 'title')}>
+          {errorText || t('dovetail.obtain_data_error')}
+        </p>
+        {hiddenRetry ? null : (
+          <kit.button
+            size="small"
+            type="ordinary"
+            onClick={e => {
+              e.stopPropagation();
+              refetch?.();
+            }}
+          >
+            {t('dovetail.retry')}
+          </kit.button>
+        )}
+      </ErrorContent>
+    </ErrorWrapper>
+  );
+};
+
+export default WidgetErrorContent;

--- a/packages/refine/src/components/YamlEditor/YamlEditorComponent.tsx
+++ b/packages/refine/src/components/YamlEditor/YamlEditorComponent.tsx
@@ -98,7 +98,7 @@ export const YamlEditorComponent = forwardRef<YamlEditorHandle, YamlEditorProps>
           editorInstance.current?.getModel()?.setValue(value);
         },
         getEditorValue: () => {
-          return editorInstance.current?.getValue() || '';
+          return editorInstance.current?.getValue() ?? '';
         },
         getEditorInstance: () => editorInstance.current || null,
       };

--- a/packages/refine/src/components/YamlForm/index.tsx
+++ b/packages/refine/src/components/YamlForm/index.tsx
@@ -7,17 +7,29 @@ import { YamlEditorComponent } from 'src/components/YamlEditor/YamlEditorCompone
 import { BASE_INIT_VALUE } from 'src/constants/k8s';
 import useEagleForm from 'src/hooks/useEagleForm';
 import { getCommonErrors } from 'src/utils/error';
+import ErrorContent from 'src/components/ErrorContent';
 
+const FormStyle = css`
+  height: 100%;
+`;
 const EditorStyle = css`
   flex: 1;
   height: 100%;
 `;
 
+export enum SchemaStrategy {
+  Required = 'Required',
+  Optional = 'Optional',
+  None = 'None'
+}
+
 interface YamlFormProps {
   initialValues?: Record<string, unknown>;
+  schemaStrategy?: SchemaStrategy;
 }
 
 function YamlForm(props: YamlFormProps) {
+  const { schemaStrategy = SchemaStrategy.Optional } = props;
   const {
     formProps,
     saveButtonProps,
@@ -25,8 +37,13 @@ function YamlForm(props: YamlFormProps) {
     errorResponseBody,
     mutationResult,
     isLoadingSchema,
+    fetchSchema,
   } =
-    useEagleForm();
+    useEagleForm({
+      editorOptions: {
+        isSkipSchema: schemaStrategy === SchemaStrategy.None,
+      }
+    });
   const kit = useUIKit();
   const { t, i18n } = useTranslation();
   const responseErrors = errorResponseBody
@@ -39,46 +56,53 @@ function YamlForm(props: YamlFormProps) {
         {...formProps}
         initialValues={formProps.initialValues ?? props.initialValues ?? BASE_INIT_VALUE}
         layout="horizontal"
+        className={FormStyle}
       >
-        {!isLoadingSchema ? (
-          <>
-            <kit.form.Item style={{ flex: 1 }}>
-              <YamlEditorComponent
-                {...editorProps}
-                className={EditorStyle}
-                schema={editorProps.schema || {}}
-                collapsable={false}
-              />
-            </kit.form.Item>
-            <kit.form.Item>
-              {mutationResult.error && (
-                <kit.alert
-                  message={
-                    errorResponseBody ? (
-                      <ul>
-                        {responseErrors.map((error, index) => (
-                          <li key={error}>
-                            {responseErrors.length > 1 ? index + 1 + '. ' : ''}
-                            {error}
-                          </li>
-                        ))}
-                      </ul>
-                    ) : (
-                      mutationResult.error.message
-                    )
-                  }
-                  type="error"
-                  style={{ marginTop: 16 }}
+        {(()=> {
+          if (isLoadingSchema) {
+            return <kit.loading />;
+          }
+
+          return editorProps.schema || schemaStrategy !== SchemaStrategy.Required ? (
+            <>
+              <kit.form.Item style={{ flex: 1 }}>
+                <YamlEditorComponent
+                  {...editorProps}
+                  className={EditorStyle}
+                  schema={editorProps.schema || {}}
+                  collapsable={false}
                 />
-              )}
-              <kit.button {...saveButtonProps} type="primary" style={{ marginTop: 16 }}>
-                {t('save')}
-              </kit.button>
-            </kit.form.Item>
-          </>
-        ) : (
-          <kit.loading />
-        )}
+              </kit.form.Item>
+              <kit.form.Item>
+                {mutationResult.error && (
+                  <kit.alert
+                    message={
+                      errorResponseBody ? (
+                        <ul>
+                          {responseErrors.map((error, index) => (
+                            <li key={error}>
+                              {responseErrors.length > 1 ? index + 1 + '. ' : ''}
+                              {error}
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        mutationResult.error.message
+                      )
+                    }
+                    type="error"
+                    style={{ marginTop: 16 }}
+                  />
+                )}
+                <kit.button {...saveButtonProps} type="primary" style={{ marginTop: 16 }}>
+                  {t('save')}
+                </kit.button>
+              </kit.form.Item>
+            </>
+          ) : (
+            <ErrorContent errorText={t('dovetail.fetch_schema_fail')} refetch={fetchSchema}></ErrorContent>
+          );
+        })()}
       </kit.form>
     </FormLayout>
   );

--- a/packages/refine/src/components/YamlForm/index.tsx
+++ b/packages/refine/src/components/YamlForm/index.tsx
@@ -18,7 +18,14 @@ interface YamlFormProps {
 }
 
 function YamlForm(props: YamlFormProps) {
-  const { formProps, saveButtonProps, editorProps, errorResponseBody, mutationResult } =
+  const {
+    formProps,
+    saveButtonProps,
+    editorProps,
+    errorResponseBody,
+    mutationResult,
+    isLoadingSchema,
+  } =
     useEagleForm();
   const kit = useUIKit();
   const { t, i18n } = useTranslation();
@@ -33,13 +40,13 @@ function YamlForm(props: YamlFormProps) {
         initialValues={formProps.initialValues ?? props.initialValues ?? BASE_INIT_VALUE}
         layout="horizontal"
       >
-        {editorProps.schema ? (
+        {!isLoadingSchema ? (
           <>
             <kit.form.Item style={{ flex: 1 }}>
               <YamlEditorComponent
                 {...editorProps}
                 className={EditorStyle}
-                schema={editorProps.schema}
+                schema={editorProps.schema || {}}
                 collapsable={false}
               />
             </kit.form.Item>

--- a/packages/refine/src/hooks/useEagleForm.ts
+++ b/packages/refine/src/hooks/useEagleForm.ts
@@ -52,6 +52,7 @@ export type UseFormProps<
   warnWhenUnsavedChanges?: boolean;
   editorOptions?: {
     isGenerateAnnotations?: boolean;
+    isSkipSchema?: boolean;
   };
 };
 
@@ -79,12 +80,14 @@ export type UseFormReturnType<
   schema: JSONSchema7 | null;
   isLoadingSchema: boolean;
   loadSchemaError: Error | null;
+  fetchSchema: ()=> void;
   enableEditor: boolean;
   errorResponseBody?: Record<string, unknown> | null;
   switchEditor: () => void;
   onFinish: (
     values?: TVariables
   ) => Promise<CreateResponse<TResponse> | UpdateResponse<TResponse> | void>;
+
 };
 
 const useEagleForm = <
@@ -149,7 +152,9 @@ const useEagleForm = <
   > | null>(null);
   const useResourceResult = useResource();
   const kit = useUIKit();
-  const { schema, loading: isLoadingSchema, error: loadSchemaError } = useSchema();
+  const { schema, loading: isLoadingSchema, error: loadSchemaError, fetchSchema } = useSchema({
+    skip: editorOptions?.isSkipSchema
+  });
   const [formAnt] = kit.form.useForm();
   const formSF = useFormSF({
     form: formAnt,
@@ -311,6 +316,7 @@ const useEagleForm = <
     schema,
     isLoadingSchema,
     loadSchemaError,
+    fetchSchema,
     switchEditor() {
       if (enableEditor && editor.current?.getEditorValue()) {
         const value = yaml.load(editor.current?.getEditorValue()) as Record<

--- a/packages/refine/src/hooks/useEagleForm.ts
+++ b/packages/refine/src/hooks/useEagleForm.ts
@@ -76,6 +76,9 @@ export type UseFormReturnType<
     onClick: () => void;
   };
   editorProps: EditorProps;
+  schema: JSONSchema7 | null;
+  isLoadingSchema: boolean;
+  loadSchemaError: Error | null;
   enableEditor: boolean;
   errorResponseBody?: Record<string, unknown> | null;
   switchEditor: () => void;
@@ -146,7 +149,7 @@ const useEagleForm = <
   > | null>(null);
   const useResourceResult = useResource();
   const kit = useUIKit();
-  const schema = useSchema();
+  const { schema, loading: isLoadingSchema, error: loadSchemaError } = useSchema();
   const [formAnt] = kit.form.useForm();
   const formSF = useFormSF({
     form: formAnt,
@@ -305,6 +308,9 @@ const useEagleForm = <
     editorProps,
     enableEditor,
     errorResponseBody,
+    schema,
+    isLoadingSchema,
+    loadSchemaError,
     switchEditor() {
       if (enableEditor && editor.current?.getEditorValue()) {
         const value = yaml.load(editor.current?.getEditorValue()) as Record<

--- a/packages/refine/src/hooks/useK8sYamlEditor.ts
+++ b/packages/refine/src/hooks/useK8sYamlEditor.ts
@@ -1,8 +1,9 @@
 import * as monaco from 'monaco-editor';
+import { useCallback } from 'react';
 
 function useK8sYamlEditor() {
 
-  function foldSymbol(editor: monaco.editor.IStandaloneCodeEditor, symbol: string) {
+  const foldSymbol = useCallback(function (editor: monaco.editor.IStandaloneCodeEditor, symbol: string) {
     const model = editor.getModel();
 
     const matchs = model?.findMatches(
@@ -28,9 +29,9 @@ function useK8sYamlEditor() {
         reject(e);
       }
     });
-  }
+  }, []);
 
-  async function fold(editor: monaco.editor.IStandaloneCodeEditor) {
+  const fold = useCallback(async function (editor: monaco.editor.IStandaloneCodeEditor) {
     await editor.getAction('editor.unfoldAll').run();
     const symbols = [
       '  annotations:',
@@ -44,7 +45,7 @@ function useK8sYamlEditor() {
     }
 
     editor.setScrollPosition({scrollTop: 0});
-  }
+  }, [foldSymbol]);
 
   return {
     fold,

--- a/packages/refine/src/locales/en-US/dovetail.json
+++ b/packages/refine/src/locales/en-US/dovetail.json
@@ -8,5 +8,8 @@
   "yaml_value_wrong": "Configuration has invalid values.",
   "edit_yaml": "Edit YAML",
   "copied": "Copied",
-  "already_reset": "Already reset"
+  "already_reset": "Already reset",
+  "fetch_schema_fail": "Failed to fetch schema.",
+  "obtain_data_error": "Having trouble getting data.",
+  "retry": "Retry"
 }

--- a/packages/refine/src/locales/zh-CN/dovetail.json
+++ b/packages/refine/src/locales/zh-CN/dovetail.json
@@ -62,5 +62,8 @@
   "select_container": "选择容器",
   "wrap": "折叠",
   "resume_log": "继续",
-  "log_new_lines": "，并展示 {{ count }} 行新日志"
+  "log_new_lines": "，并展示 {{ count }} 行新日志",
+  "fetch_schema_fail": "获取 schema 失败。",
+  "obtain_data_error": "获取数据时遇到问题。",
+  "retry": "重试"
 }


### PR DESCRIPTION
添加获取 Schema 的不同策略。

#### Required

获取 Schema 失败时展示错误页面

![image](https://github.com/webzard-io/dovetail-v2/assets/25414733/2fa275ca-7a7e-4f29-ac03-2aa55b220260)

#### Optional

获取失败时正常展示编辑器，但无 Schema 校验

<img width="1679" alt="image" src="https://github.com/webzard-io/dovetail-v2/assets/25414733/a6150d9e-3770-4a00-be43-703d51207051">

获取成功有 Schema 校验

<img width="1677" alt="image" src="https://github.com/webzard-io/dovetail-v2/assets/25414733/b9faab69-457d-4d99-83de-489ceb8848bf">


#### None 

不发起 Schema 请求，无校验
