### PR TITLE
add restarts number for deployments

### DIFF
--- a/packages/refine/src/components/ShowContent/fields.tsx
+++ b/packages/refine/src/components/ShowContent/fields.tsx
@@ -10,6 +10,8 @@ import { KeyValue } from '../KeyValue';
 import Time from '../Time';
 import { WorkloadPodsTable } from '../WorkloadPodsTable';
 import { WorkloadReplicas } from '../WorkloadReplicas';
+import { usePods } from '../../hooks/usePods';
+import { get, sumBy } from 'lodash-es';
 
 export type ShowField<Model extends ResourceModel> = {
   key: string;
@@ -25,6 +27,18 @@ export const ImageField = (i18n: i18n): ShowField<WorkloadModel> => {
     path: ['imageNames'],
     render(value) {
       return <ImageNames value={value as string[]} />;
+    },
+  };
+};
+export const WorkloadRestartsField = (i18n: i18n): ShowField<WorkloadModel> => {
+  return {
+    key: 'restarts',
+    title: i18n.t('restarts'),
+    path: [],
+    render(_, record) {
+      const { pods } = usePods(get(record, 'spec.selector')!);
+      const restarts = sumBy(pods, 'restartCount');
+      return <span>{restarts}</span>;
     },
   };
 };

--- a/packages/refine/src/components/WorkloadPodsTable/WorkloadPodsTable.tsx
+++ b/packages/refine/src/components/WorkloadPodsTable/WorkloadPodsTable.tsx
@@ -1,11 +1,8 @@
 import { useUIKit } from '@cloudtower/eagle';
 import { css } from '@linaria/core';
-import { useList } from '@refinedev/core';
-import { Pod } from 'kubernetes-types/core/v1';
 import { LabelSelector } from 'kubernetes-types/meta/v1';
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { matchSelector } from 'src/utils/selector';
 import {
   NameColumnRenderer,
   NodeNameColumnRenderer,
@@ -14,9 +11,9 @@ import {
   WorkloadImageColumnRenderer,
 } from '../../hooks/useEagleTable/columns';
 import { PodModel } from '../../model';
-import { WithId } from '../../types';
 import Table, { Column } from '../Table';
 import { TableToolBar } from '../Table/TableToolBar';
+import { usePods } from '../../hooks/usePods';
 
 export const WorkloadPodsTable: React.FC<{ selector?: LabelSelector }> = ({
   selector,
@@ -26,18 +23,7 @@ export const WorkloadPodsTable: React.FC<{ selector?: LabelSelector }> = ({
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
   const [currentPage, setCurrentPage] = useState<number>(1);
 
-  const { data } = useList({
-    resource: 'pods',
-    meta: { resourceBasePath: '/api/v1', kind: 'Pod' },
-  });
-
-  const dataSource = useMemo(() => {
-    return data?.data
-      .map(p => new PodModel(p as WithId<Pod>))
-      .filter(p => {
-        return selector ? matchSelector(p, selector) : true;
-      });
-  }, [data?.data, selector]);
+  const { pods, isLoading } = usePods(selector);
 
   const columns: Column<PodModel>[] = [
     PhaseColumnRenderer(i18n),
@@ -56,8 +42,8 @@ export const WorkloadPodsTable: React.FC<{ selector?: LabelSelector }> = ({
     >
       <TableToolBar title="" selectedKeys={selectedKeys} hideCreate />
       <Table
-        loading={!dataSource}
-        dataSource={dataSource || []}
+        loading={isLoading}
+        dataSource={pods || []}
         columns={columns}
         onSelect={keys => setSelectedKeys(keys as string[])}
         rowKey="id"

--- a/packages/refine/src/hooks/useEagleTable/columns.tsx
+++ b/packages/refine/src/hooks/useEagleTable/columns.tsx
@@ -1,7 +1,7 @@
 import { useUIKit } from '@cloudtower/eagle';
 import { useGo, useNavigation, useParsed } from '@refinedev/core';
 import { i18n } from 'i18next';
-import { get } from 'lodash';
+import { get, sumBy } from 'lodash';
 import React from 'react';
 import { ImageNames } from '../../components/ImageNames';
 import { StateTag } from '../../components/StateTag';
@@ -10,6 +10,7 @@ import Time from '../../components/Time';
 import { WorkloadReplicas } from '../../components/WorkloadReplicas';
 import { JobModel, PodModel, ResourceModel } from '../../model';
 import { WorkloadModel } from '../../model/workload-model';
+import { usePods } from '../usePods';
 
 const NameLink: React.FC<{ id: string; name: string; resource?: string }> = props => {
   const { name, id, resource } = props;
@@ -106,6 +107,24 @@ export const WorkloadImageColumnRenderer = <Model extends ResourceModel>(
     sorter: CommonSorter(dataIndex),
     render(value) {
       return <ImageNames value={value} />;
+    },
+  };
+};
+
+export const WorkloadRestartsColumnRenderer = <Model extends WorkloadModel>(
+  i18n: i18n
+): Column<Model> => {
+  const dataIndex = ['restarts'];
+  return {
+    key: 'restarts',
+    display: true,
+    dataIndex,
+    title: i18n.t('restarts'),
+    sortable: false,
+    render(_, record) {
+      const { pods } = usePods(get(record, 'spec.selector')!);
+      const restarts = sumBy(pods, 'restartCount');
+      return <span>{restarts}</span>;
     },
   };
 };

--- a/packages/refine/src/hooks/usePods.ts
+++ b/packages/refine/src/hooks/usePods.ts
@@ -1,0 +1,24 @@
+import { useList } from '@refinedev/core';
+import { Pod } from 'kubernetes-types/core/v1';
+import { LabelSelector } from 'kubernetes-types/meta/v1';
+import { useMemo } from 'react';
+import { matchSelector } from 'src/utils/selector';
+import { PodModel } from '../model';
+import { WithId } from '../types';
+
+export const usePods = (selector?: LabelSelector) => {
+  const { data, isLoading } = useList({
+    resource: 'pods',
+    meta: { resourceBasePath: '/api/v1', kind: 'Pod' },
+  });
+
+  const pods = useMemo(() => {
+    return data?.data
+      .map(p => new PodModel(p as WithId<Pod>))
+      .filter(p => {
+        return selector ? matchSelector(p, selector) : true;
+      });
+  }, [data?.data, selector]);
+
+  return { pods, isLoading };
+};

--- a/packages/refine/src/model/workload-model.ts
+++ b/packages/refine/src/model/workload-model.ts
@@ -35,11 +35,6 @@ export class WorkloadModel<
     return containers?.map(container => shortenedImage(container.image || '')) || [];
   }
 
-  get restartCount() {
-    // TODO: need count from pods
-    return 0;
-  }
-
   redeploy() {
     const newOne = cloneDeep(this.rawYaml);
     const path = 'spec.template.metadata.annotations';

--- a/packages/refine/src/pages/deployments/list/index.tsx
+++ b/packages/refine/src/pages/deployments/list/index.tsx
@@ -8,6 +8,7 @@ import { useEagleTable } from 'src/hooks/useEagleTable';
 import {
   AgeColumnRenderer,
   WorkloadImageColumnRenderer,
+  WorkloadRestartsColumnRenderer,
   NameColumnRenderer,
   NameSpaceColumnRenderer,
   PhaseColumnRenderer,
@@ -26,6 +27,7 @@ export const DeploymentList: React.FC<IResourceComponentsProps> = () => {
       NameColumnRenderer(i18n),
       NameSpaceColumnRenderer(i18n),
       WorkloadImageColumnRenderer(i18n),
+      WorkloadRestartsColumnRenderer(i18n),
       ReplicasColumnRenderer(i18n),
       AgeColumnRenderer(i18n),
     ],

--- a/packages/refine/src/pages/deployments/show/index.tsx
+++ b/packages/refine/src/pages/deployments/show/index.tsx
@@ -8,6 +8,7 @@ import {
   ImageField,
   PodsField,
   ReplicaField,
+  WorkloadRestartsField,
 } from '../../../components/ShowContent/fields';
 import { WorkloadDropdown } from '../../../components/WorkloadDropdown';
 import { WorkloadModel } from '../../../model';
@@ -20,7 +21,7 @@ export const DeploymentShow: React.FC<IResourceComponentsProps> = () => {
     <PageShow<WithId<Deployment>, WorkloadModel>
       fieldGroups={[
         [],
-        [ImageField(i18n), ReplicaField(i18n)],
+        [ImageField(i18n), ReplicaField(i18n), WorkloadRestartsField(i18n)],
         [PodsField(i18n), ConditionsField(i18n)],
       ]}
       formatter={d => new WorkloadModel(d)}


### PR DESCRIPTION
### Feature
1. 添加重启次数的显示。
2. 封装一个 `usePods` hook，复用通过selector筛选pod。

Deployment、StatefulSet等资源有要显示重启次数。它们的重启次数是根据它们所拥有的Pod的重启次数之和。
因为涉及到两个资源和异步逻辑，暂时不能再Model中计算重启次数，只能放在UI层去获取Pod加以计算。因为Pod数据会缓存，所以不会造成额外的请求。

![截屏2023-12-13 下午6 15 04](https://github.com/webzard-io/dovetail-v2/assets/12260952/4e6787bb-06a8-41a1-931c-c729e8260b24)
![截屏2023-12-13 下午6 15 00](https://github.com/webzard-io/dovetail-v2/assets/12260952/ca256961-623d-40ed-bc84-4948898f0bcb)


