### PR TITLE
fix: turn off the live mode in yaml form

### DIFF
--- a/packages/refine/src/components/YamlForm/index.tsx
+++ b/packages/refine/src/components/YamlForm/index.tsx
@@ -42,6 +42,7 @@ function YamlForm(props: YamlFormProps) {
     editorOptions: {
       isSkipSchema: schemaStrategy === SchemaStrategy.None,
     },
+    liveMode: 'off'
   });
   const kit = useUIKit();
   const { t, i18n } = useTranslation();

--- a/packages/refine/src/hooks/useEagleForm.ts
+++ b/packages/refine/src/hooks/useEagleForm.ts
@@ -208,16 +208,22 @@ const useEagleForm = <
   const warnWhenUnsavedChanges =
     warnWhenUnsavedChangesProp ?? warnWhenUnsavedChangesRefine;
 
+  // Init the editor after the resource value is fetched
   React.useEffect(() => {
+    form.resetFields();
+
     if (editor.current) {
+      const editorValue = yaml.dump(form.getFieldsValue(true));
       const editorInstance = editor.current.getEditorInstance();
 
+      editor.current.setEditorValue(editorValue);
+      editor.current.setValue(editorValue);
       if (queryResult?.data?.data && editorInstance && !isFoldRef.current) {
         fold(editorInstance);
         isFoldRef.current = true;
       }
     }
-  }, [queryResult?.data?.data, id, fold]);
+  }, [queryResult?.data?.data, id, form, fold]);
 
   React.useEffect(() => {
     const response = useFormCoreResult.mutationResult.error?.response;


### PR DESCRIPTION
修复编辑页面刷新后表单值不正确的问题，并关闭 liveMode 防止后续值变化时意外修改表单