### PR TITLE
pass globalStore to d2

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.0.14-beta.5",
+  "version": "0.0.14-beta.6",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.0.14-beta.2",
+  "version": "0.0.14-beta.5",
   "type": "module",
   "files": [
     "dist",
@@ -20,7 +20,7 @@
     "dayjs": "^1.11.10",
     "i18next": "^23.2.3",
     "js-yaml": "^4.1.0",
-    "k8s-api-provider": "0.0.15-beta.2",
+    "k8s-api-provider": "0.0.15-beta.6",
     "ky": "^0.33.3",
     "lodash-es": "^4.17.21",
     "mitt": "^3.0.1",

--- a/packages/refine/src/App.tsx
+++ b/packages/refine/src/App.tsx
@@ -1,4 +1,5 @@
 import { createBrowserHistory } from 'history';
+import { GlobalStore } from 'k8s-api-provider';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Route, Router } from 'react-router-dom';
@@ -14,6 +15,7 @@ import { SecretsConfig } from './pages/secrets';
 import { ServicesConfig } from './pages/services';
 import { StatefulSetShow, StatefulSetList, StatefulSetForm } from './pages/statefulsets';
 
+import { ProviderPlugins } from './plugins';
 import { RESOURCE_GROUP, ResourceConfig } from './types';
 
 function App() {
@@ -89,18 +91,23 @@ function App() {
       },
     ];
   }, [t]);
-
+  const globalStore = useMemo(() => {
+    return new GlobalStore(
+      {
+        apiUrl: '/api/k8s',
+        watchWsApiUrl: 'api/sks-ws/k8s',
+        prefix: 'default',
+      },
+      ProviderPlugins
+    );
+  }, []);
   return (
     <Dovetail
       resourcesConfig={resourcesConfig as ResourceConfig[]}
       refineResources={refineResources}
       Layout={Layout}
       history={histroy}
-      globalStoreParams={{
-        apiUrl: '/api/k8s',
-        watchWsApiUrl: 'api/sks-ws/k8s',
-        prefix: 'default',
-      }}
+      globalStore={globalStore}
     >
       <Router history={histroy}>
         <Route path="/cronjobs" exact>

--- a/packages/refine/src/Dovetail.tsx
+++ b/packages/refine/src/Dovetail.tsx
@@ -4,13 +4,11 @@ import {
   dataProvider,
   liveProvider,
   GlobalStore,
-  GlobalStoreInitParams,
 } from 'k8s-api-provider';
 import React, { useMemo } from 'react';
 import { Router } from 'react-router-dom';
 import { ResourceCRUD } from './components/ResourceCRUD';
 import GlobalStoreContext from './contexts/global-store';
-import { ProviderPlugins } from './plugins';
 import { routerProvider } from './providers/router-provider';
 import './i18n';
 
@@ -25,15 +23,11 @@ type Props = {
   refineResources?: ResourceProps[];
   Layout?: React.FC<unknown>;
   history: History;
-  globalStoreParams: GlobalStoreInitParams;
+  globalStore: GlobalStore;
 };
 
 export const Dovetail: React.FC<Props> = props => {
-  const { resourcesConfig, urlPrefix = '', Layout, history, globalStoreParams } = props;
-
-  const globalStore = useMemo(() => {
-    return new GlobalStore(globalStoreParams, ProviderPlugins);
-  }, [globalStoreParams]);
+  const { resourcesConfig, urlPrefix = '', Layout, history, globalStore } = props;
 
   const notCustomResources = useMemo(() => {
     return resourcesConfig.filter(c => !c.isCustom);

--- a/packages/refine/src/components/ListPage/index.tsx
+++ b/packages/refine/src/components/ListPage/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css, cx } from '@linaria/core';
 import React, { useContext } from 'react';
 import BaseTable from 'src/components/Table';
 import { TableProps } from 'src/components/Table';
@@ -35,7 +35,11 @@ export function ListPage<T extends ResourceModel>(props: ListPageProps<T>) {
   return (
     <div className={ListPageStyle}>
       <TableToolBar title={title} selectedKeys={selectedKeys} />
-      <Table {...tableProps} className={TableStyle} scroll={{ y: 'calc(100% - 48px)' }} />
+      <Table
+        {...tableProps}
+        className={cx(tableProps.className, TableStyle)}
+        scroll={{ y: 'calc(100% - 48px)' }}
+      />
     </div>
   );
 }

--- a/packages/refine/src/contexts/index.ts
+++ b/packages/refine/src/contexts/index.ts
@@ -1,1 +1,2 @@
 export { default as ComponentContext } from './component';
+export { default as GlobalStoreContext } from './global-store';

--- a/packages/refine/src/index.ts
+++ b/packages/refine/src/index.ts
@@ -7,4 +7,4 @@ export * from './Dovetail';
 export * from './types';
 export * from './contexts';
 export * from './models';
-
+export * from './plugins';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7518,10 +7518,10 @@ jsprim@^1.2.2:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
-k8s-api-provider@0.0.15-beta.0:
-  version "0.0.15-beta.0"
-  resolved "https://registry.npmmirror.com/k8s-api-provider/-/k8s-api-provider-0.0.15-beta.0.tgz#6bce289e8ab24677ddd7ee4fa3c3cbcb47ce3bbe"
-  integrity sha512-9IwDoeYDhG/xtlLlp1u+Yj014FBvEKMMa+DkjSBP4z3DyUKmcfvJvsjMVDUOmint7w9FQFfbP1wXxNs7w5P6ow==
+k8s-api-provider@0.0.15-beta.4:
+  version "0.0.15-beta.4"
+  resolved "https://registry.npmmirror.com/k8s-api-provider/-/k8s-api-provider-0.0.15-beta.4.tgz#130f40d8937792eb5e1c9b4a5605ceebe99b1bc1"
+  integrity sha512-YuQ2GH0+2QqvU2TJ6hbN9oX0pE/KEeU2JpBO8+I3Uo/XBuCi4/p003Z9zXChpWCRfHJxJzlylEV6+k/3wl26Dw==
   dependencies:
     kubernetes-types "^1.26.0"
     ky "^0.33.3"


### PR DESCRIPTION
1. 为了支持应用中存在多个 d2 实例的情况，需要让多个 d2 实例共享 globalStore。所以 d2 需要支持传入 globalStore 作为参数
2. ListPage 允许传className给table的小改动