### PR TITLE
add stateDisplay for workloads

### DIFF
--- a/packages/refine/src/components/CronjobJobsTable/index.tsx
+++ b/packages/refine/src/components/CronjobJobsTable/index.tsx
@@ -9,7 +9,7 @@ import {
   DurationColumnRenderer,
   NameColumnRenderer,
   NameSpaceColumnRenderer,
-  PhaseColumnRenderer,
+  StateDisplayColumnRenderer,
   WorkloadImageColumnRenderer,
 } from '../../hooks/useEagleTable/columns';
 import { CronJobModel } from '../../models';
@@ -54,8 +54,8 @@ export const CronjobJobsTable: React.FC<{
   }, [data?.data, owner]);
 
   const columns: Column<CronJobModel>[] = [
-    PhaseColumnRenderer(),
     NameColumnRenderer('jobs'),
+    StateDisplayColumnRenderer(),
     NameSpaceColumnRenderer(),
     WorkloadImageColumnRenderer(),
     CompletionsCountColumnRenderer(),
@@ -72,7 +72,7 @@ export const CronjobJobsTable: React.FC<{
     >
       <TableToolBar title="Jobs" selectedKeys={selectedKeys} hideCreate />
       <Table
-        tableKey='cronjobs'
+        tableKey="cronjobs"
         loading={!dataSource}
         data={dataSource || []}
         columns={columns}

--- a/packages/refine/src/components/PodContainersTable/PodContainersTable.tsx
+++ b/packages/refine/src/components/PodContainersTable/PodContainersTable.tsx
@@ -11,6 +11,7 @@ import { WithId } from '../../types';
 import { addId } from '../../utils/addId';
 import { StateTag } from '../StateTag';
 import Time from '../Time';
+import { WorkloadState } from '../../constants';
 
 type Props = {
   containerStatuses: ContainerStatus[];
@@ -32,7 +33,7 @@ export const PodContainersTable: React.FC<Props> = ({
         title: i18n.t('dovetail.state'),
         sortable: true,
         sorter: CommonSorter(['state']),
-        render: v => <StateTag state={Object.keys(v)[0]} />,
+        render: v => <StateTag state={Object.keys(v)[0] as WorkloadState} />,
       },
       {
         key: 'ready',

--- a/packages/refine/src/components/ResourceCRUD/list/index.tsx
+++ b/packages/refine/src/components/ResourceCRUD/list/index.tsx
@@ -1,11 +1,7 @@
 import { IResourceComponentsProps } from '@refinedev/core';
 import React from 'react';
 import { useEagleTable } from '../../../hooks/useEagleTable';
-import {
-  NameColumnRenderer,
-  NameSpaceColumnRenderer,
-  PhaseColumnRenderer,
-} from '../../../hooks/useEagleTable/columns';
+import { NameColumnRenderer } from '../../../hooks/useEagleTable/columns';
 import { ResourceModel } from '../../../models';
 import { ListPage } from '../../ListPage';
 import { Column } from '../../Table';
@@ -20,12 +16,7 @@ export function ResourceList<Model extends ResourceModel>(props: Props<Model>) {
   const { formatter, name, columns, Dropdown } = props;
   const { tableProps, selectedKeys } = useEagleTable<Model>({
     useTableParams: {},
-    columns: [
-      NameColumnRenderer(),
-      PhaseColumnRenderer(),
-      NameSpaceColumnRenderer(),
-      ...columns,
-    ],
+    columns: [NameColumnRenderer(), ...columns],
     tableProps: {
       currentSize: 10,
     },

--- a/packages/refine/src/components/StateTag/StateTag.tsx
+++ b/packages/refine/src/components/StateTag/StateTag.tsx
@@ -1,22 +1,27 @@
 import { TagColor, useUIKit } from '@cloudtower/eagle';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { WorkloadState } from '../../constants';
 
 type Props = {
-  state?: string;
+  state?: WorkloadState;
 };
 
-export const StateTag: React.FC<Props> = ({ state }) => {
+export const StateTag: React.FC<Props> = ({ state = WorkloadState.UPDATEING }) => {
   const kit = useUIKit();
-  const colorMap: Record<string, TagColor> = {
-    running: 'green',
-    active: 'green',
-    succeeded: 'blue',
-    terminated: 'red',
+  const { t } = useTranslation();
+  const colorMap: Record<WorkloadState, TagColor> = {
+    updating: 'blue',
+    ready: 'green',
+    completed: 'green',
+    failed: 'red',
+    suspended: 'gray',
+    running: 'blue',
+    succeeded: 'green',
+    unknown: 'gray',
+    terminating: 'gray',
     pending: 'gray',
+    waiting: 'gray',
   };
-  return (
-    <kit.tag color={colorMap[state?.toLowerCase() || ''] || 'green'}>
-      {state || 'Active'}
-    </kit.tag>
-  );
+  return <kit.tag color={colorMap[state]}>{t(`dovetail.${state || 'updaing'}`)}</kit.tag>;
 };

--- a/packages/refine/src/components/WorkloadPodsTable/WorkloadPodsTable.tsx
+++ b/packages/refine/src/components/WorkloadPodsTable/WorkloadPodsTable.tsx
@@ -7,8 +7,8 @@ import { matchSelector } from 'src/utils/selector';
 import {
   NameColumnRenderer,
   NodeNameColumnRenderer,
-  PhaseColumnRenderer,
   RestartCountColumnRenderer,
+  StateDisplayColumnRenderer,
   WorkloadImageColumnRenderer,
 } from '../../hooks/useEagleTable/columns';
 import { PodModel } from '../../models';
@@ -34,7 +34,7 @@ export const WorkloadPodsTable: React.FC<{ selector?: LabelSelector }> = ({
   }, [data?.data, selector]);
 
   const columns: Column<PodModel>[] = [
-    PhaseColumnRenderer(),
+    StateDisplayColumnRenderer(),
     NameColumnRenderer('pods'),
     NodeNameColumnRenderer(),
     WorkloadImageColumnRenderer(),

--- a/packages/refine/src/constants/index.ts
+++ b/packages/refine/src/constants/index.ts
@@ -1,1 +1,2 @@
 export * from './k8s';
+export * from './state';

--- a/packages/refine/src/constants/state.ts
+++ b/packages/refine/src/constants/state.ts
@@ -1,0 +1,15 @@
+export enum WorkloadState {
+  UPDATEING = 'updating',
+  READY = 'ready',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+  SUSPENDED = 'suspended',
+  RUNNING = 'running',
+  SUCCEEDED = 'succeeded',
+  UNKNOWN = 'unknown',
+  TERMINATING = 'terminating',
+  PENDING = 'pending',
+  WAITING = 'waiting',
+}
+
+// export type DeploymentState = WorkloadState.UPDATEING | WorkloadState.READY;

--- a/packages/refine/src/hooks/useEagleTable/columns.tsx
+++ b/packages/refine/src/hooks/useEagleTable/columns.tsx
@@ -81,13 +81,15 @@ export const NameSpaceColumnRenderer = <Model extends ResourceModel>(): Column<M
   };
 };
 
-export const PhaseColumnRenderer = <Model extends ResourceModel>(): Column<Model> => {
-  const dataIndex = ['status', 'phase'];
+export const StateDisplayColumnRenderer = <
+  Model extends WorkloadModel | CronJobModel | PodModel,
+>(): Column<Model> => {
+  const dataIndex = ['stateDisplay'];
   return {
-    key: 'phase',
+    key: 'stateDisplay',
     display: true,
     dataIndex: dataIndex,
-    title: i18n.t('dovetail.phase'),
+    title: i18n.t('dovetail.state'),
     sortable: true,
     sorter: CommonSorter(dataIndex),
     render: v => <StateTag state={v} />,

--- a/packages/refine/src/locales/zh-CN/dovetail.json
+++ b/packages/refine/src/locales/zh-CN/dovetail.json
@@ -46,7 +46,6 @@
   "duration": "持续时间",
   "completions": "完成 Job 历史数",
   "started": "开始时间",
-  "ready": "就绪",
   "init_container": "初始化容器",
   "container": "容器",
   "redeploy": "重新部署",
@@ -65,5 +64,16 @@
   "log_new_lines": "，并展示 {{ count }} 行新日志",
   "fetch_schema_fail": "获取 schema 失败。",
   "obtain_data_error": "获取数据时遇到问题。",
-  "retry": "重试"
+  "retry": "重试",
+  "ready": "就绪",
+  "updating": "更新中",
+  "completed": "完成",
+  "failed": "异常",
+  "suspended": "挂起",
+  "running": "运行中",
+  "terminating": "终止",
+  "succeeded": "成功终止",
+  "unknown": "未知",
+  "pending": "待处理",
+  "waiting": "等待中"
 }

--- a/packages/refine/src/models/cronjob-model.ts
+++ b/packages/refine/src/models/cronjob-model.ts
@@ -1,6 +1,7 @@
 import { GlobalStore, Unstructured } from 'k8s-api-provider';
 import { CronJob } from 'kubernetes-types/batch/v1';
 import { set, cloneDeep } from 'lodash';
+import { WorkloadState } from '../constants';
 import { WorkloadBaseModel } from './workload-base-model';
 
 type RequiredCronJob = Required<CronJob> & Unstructured;
@@ -14,6 +15,13 @@ export class CronJobModel extends WorkloadBaseModel {
     public _globalStore: GlobalStore
   ) {
     super(_rawYaml, _globalStore);
+  }
+
+  get stateDisplay() {
+    if (!this.spec?.suspend) {
+      return WorkloadState.SUSPENDED;
+    }
+    return WorkloadState.RUNNING;
   }
 
   suspend() {

--- a/packages/refine/src/models/daemonset-model.ts
+++ b/packages/refine/src/models/daemonset-model.ts
@@ -1,0 +1,25 @@
+import { GlobalStore, Unstructured } from 'k8s-api-provider';
+import { DaemonSet } from 'kubernetes-types/apps/v1';
+import { WorkloadState } from '../constants';
+import { WorkloadModel } from './workload-model';
+
+type RequiredDaemonSet = Required<DaemonSet> & Unstructured;
+
+export class DaemonSetModel extends WorkloadModel {
+  public declare spec?: RequiredDaemonSet['spec'];
+  public declare status?: RequiredDaemonSet['status'];
+
+  constructor(
+    public _rawYaml: RequiredDaemonSet,
+    public _globalStore: GlobalStore
+  ) {
+    super(_rawYaml, _globalStore);
+  }
+
+  get stateDisplay() {
+    if (this.status?.desiredNumberScheduled !== this.status?.numberReady) {
+      return WorkloadState.UPDATEING;
+    }
+    return WorkloadState.READY;
+  }
+}

--- a/packages/refine/src/models/deployment-model.ts
+++ b/packages/refine/src/models/deployment-model.ts
@@ -1,0 +1,25 @@
+import { GlobalStore, Unstructured } from 'k8s-api-provider';
+import { Deployment } from 'kubernetes-types/apps/v1';
+import { WorkloadState } from '../constants';
+import { WorkloadModel } from './workload-model';
+
+type RequiredDeployment = Required<Deployment> & Unstructured;
+
+export class DeploymentModel extends WorkloadModel {
+  public declare spec?: RequiredDeployment['spec'];
+  public declare status?: RequiredDeployment['status'];
+
+  constructor(
+    public _rawYaml: RequiredDeployment,
+    public _globalStore: GlobalStore
+  ) {
+    super(_rawYaml, _globalStore);
+  }
+
+  get stateDisplay() {
+    if (this.spec?.replicas !== this.status?.readyReplicas) {
+      return WorkloadState.UPDATEING;
+    }
+    return WorkloadState.READY;
+  }
+}

--- a/packages/refine/src/models/index.ts
+++ b/packages/refine/src/models/index.ts
@@ -7,3 +7,6 @@ export * from './resource-model';
 export * from './workload-model';
 export * from './cronjob-model';
 export * from './event-model';
+export * from './deployment-model';
+export * from './daemonset-model';
+export * from './statefulset-model';

--- a/packages/refine/src/models/statefulset-model.ts
+++ b/packages/refine/src/models/statefulset-model.ts
@@ -1,0 +1,25 @@
+import { GlobalStore, Unstructured } from 'k8s-api-provider';
+import { StatefulSet } from 'kubernetes-types/apps/v1';
+import { WorkloadState } from '../constants';
+import { WorkloadModel } from './workload-model';
+
+type RequiredStatefulSet = Required<StatefulSet> & Unstructured;
+
+export class StatefulSetModel extends WorkloadModel {
+  public declare spec?: RequiredStatefulSet['spec'];
+  public declare status?: RequiredStatefulSet['status'];
+
+  constructor(
+    public _rawYaml: RequiredStatefulSet,
+    public _globalStore: GlobalStore
+  ) {
+    super(_rawYaml, _globalStore);
+  }
+
+  get stateDisplay() {
+    if (this.spec?.replicas !== this.status?.readyReplicas) {
+      return WorkloadState.UPDATEING;
+    }
+    return WorkloadState.READY;
+  }
+}

--- a/packages/refine/src/pages/cronjobs/list/index.tsx
+++ b/packages/refine/src/pages/cronjobs/list/index.tsx
@@ -9,7 +9,7 @@ import {
   WorkloadImageColumnRenderer,
   NameColumnRenderer,
   NameSpaceColumnRenderer,
-  PhaseColumnRenderer,
+  StateDisplayColumnRenderer,
 } from 'src/hooks/useEagleTable/columns';
 import i18n from '../../../i18n';
 import { CronJobModel } from '../../../models';
@@ -18,7 +18,7 @@ export const CronJobList: React.FC<IResourceComponentsProps> = () => {
   const { tableProps, selectedKeys } = useEagleTable<CronJobModel>({
     useTableParams: {},
     columns: [
-      PhaseColumnRenderer(),
+      StateDisplayColumnRenderer(),
       NameColumnRenderer(),
       NameSpaceColumnRenderer(),
       WorkloadImageColumnRenderer(),

--- a/packages/refine/src/pages/daemonsets/list/index.tsx
+++ b/packages/refine/src/pages/daemonsets/list/index.tsx
@@ -8,7 +8,7 @@ import {
   WorkloadImageColumnRenderer,
   NameColumnRenderer,
   NameSpaceColumnRenderer,
-  PhaseColumnRenderer,
+  StateDisplayColumnRenderer,
 } from 'src/hooks/useEagleTable/columns';
 import { WorkloadModel } from '../../../models';
 
@@ -16,7 +16,7 @@ export const DaemonSetList: React.FC<IResourceComponentsProps> = () => {
   const { tableProps, selectedKeys } = useEagleTable<WorkloadModel>({
     useTableParams: {},
     columns: [
-      PhaseColumnRenderer(),
+      StateDisplayColumnRenderer(),
       NameColumnRenderer(),
       NameSpaceColumnRenderer(),
       WorkloadImageColumnRenderer(),

--- a/packages/refine/src/pages/deployments/list/index.tsx
+++ b/packages/refine/src/pages/deployments/list/index.tsx
@@ -8,9 +8,9 @@ import {
   WorkloadImageColumnRenderer,
   NameColumnRenderer,
   NameSpaceColumnRenderer,
-  PhaseColumnRenderer,
   ReplicasColumnRenderer,
   WorkloadRestartsColumnRenderer,
+  StateDisplayColumnRenderer,
 } from 'src/hooks/useEagleTable/columns';
 import { WorkloadModel } from '../../../models';
 
@@ -18,7 +18,7 @@ export const DeploymentList: React.FC<IResourceComponentsProps> = () => {
   const { tableProps, selectedKeys } = useEagleTable<WorkloadModel>({
     useTableParams: {},
     columns: [
-      PhaseColumnRenderer(),
+      StateDisplayColumnRenderer(),
       NameColumnRenderer(),
       NameSpaceColumnRenderer(),
       WorkloadImageColumnRenderer(),

--- a/packages/refine/src/pages/jobs/index.ts
+++ b/packages/refine/src/pages/jobs/index.ts
@@ -13,6 +13,7 @@ import {
   WorkloadImageColumnRenderer,
   DurationColumnRenderer,
   CompletionsCountColumnRenderer,
+  StateDisplayColumnRenderer,
 } from '../../hooks/useEagleTable/columns';
 import { JobModel } from '../../models';
 import { RESOURCE_GROUP, ResourceConfig } from '../../types';
@@ -26,6 +27,7 @@ export const JobConfig: ResourceConfig<JobModel> = {
   parent: RESOURCE_GROUP.WORKLOAD,
   columns: () =>
     [
+      StateDisplayColumnRenderer(),
       WorkloadImageColumnRenderer(),
       CompletionsCountColumnRenderer(),
       DurationColumnRenderer(),

--- a/packages/refine/src/pages/pods/list/index.tsx
+++ b/packages/refine/src/pages/pods/list/index.tsx
@@ -8,10 +8,10 @@ import {
   WorkloadImageColumnRenderer,
   NameColumnRenderer,
   NameSpaceColumnRenderer,
-  PhaseColumnRenderer,
   CommonSorter,
   RestartCountColumnRenderer,
   NodeNameColumnRenderer,
+  StateDisplayColumnRenderer,
 } from 'src/hooks/useEagleTable/columns';
 import { Column } from '../../../components';
 import { PodMetricsModel, PodModel } from '../../../models';
@@ -41,7 +41,7 @@ export const PodList: React.FC<IResourceComponentsProps> = () => {
   const { tableProps, selectedKeys } = useEagleTable<PodModel>({
     useTableParams: {},
     columns: compact([
-      PhaseColumnRenderer(),
+      StateDisplayColumnRenderer(),
       NameColumnRenderer(),
       NameSpaceColumnRenderer(),
       WorkloadImageColumnRenderer(),

--- a/packages/refine/src/pages/statefulsets/list/index.tsx
+++ b/packages/refine/src/pages/statefulsets/list/index.tsx
@@ -8,7 +8,7 @@ import {
   WorkloadImageColumnRenderer,
   NameColumnRenderer,
   NameSpaceColumnRenderer,
-  PhaseColumnRenderer,
+  StateDisplayColumnRenderer,
   ReplicasColumnRenderer,
   WorkloadRestartsColumnRenderer,
 } from 'src/hooks/useEagleTable/columns';
@@ -18,7 +18,7 @@ export const StatefulSetList: React.FC<IResourceComponentsProps> = () => {
   const { tableProps, selectedKeys } = useEagleTable<WorkloadModel>({
     useTableParams: {},
     columns: [
-      PhaseColumnRenderer(),
+      StateDisplayColumnRenderer(),
       NameColumnRenderer(),
       NameSpaceColumnRenderer(),
       WorkloadImageColumnRenderer(),

--- a/packages/refine/src/plugins/model-plugin.ts
+++ b/packages/refine/src/plugins/model-plugin.ts
@@ -7,17 +7,19 @@ import {
 } from 'k8s-api-provider';
 import {
   CronJobModel,
+  DaemonSetModel,
+  DeploymentModel,
   EventModel,
   JobModel,
   PodModel,
   ResourceModel,
-  WorkloadModel,
+  StatefulSetModel,
 } from '../models';
 
 const ModelMap = {
-  Deployment: WorkloadModel,
-  DaemonSet: WorkloadModel,
-  StatefulSet: WorkloadModel,
+  Deployment: DeploymentModel,
+  DaemonSet: DaemonSetModel,
+  StatefulSet: StatefulSetModel,
   CronJob: CronJobModel,
   Job: JobModel,
   Pod: PodModel,


### PR DESCRIPTION
添加workload资源的状态字段和对应的Renderer、Field
因为每个资源的状态判断规则都不同，所以给每个资源都创建了Model

![截屏2024-01-30 17 54 56](https://github.com/webzard-io/dovetail-v2/assets/12260952/7a65e9b9-2e53-4e99-9b23-0ef109feb5b1)

![截屏2024-01-30 17 55 12](https://github.com/webzard-io/dovetail-v2/assets/12260952/b62b4b70-eff4-4b47-98fa-35057cfd9c26)
