### PR TITLE
feat: use modal to edit replicas

### DIFF
--- a/packages/refine/src/components/EditField/index.tsx
+++ b/packages/refine/src/components/EditField/index.tsx
@@ -1,0 +1,86 @@
+import { useUIKit, pushModal, popModal } from '@cloudtower/eagle';
+import { css } from '@linaria/core';
+import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FormErrorAlert } from 'src/components/FormErrorAlert';
+import { useSubmitForm} from 'src/hooks/useSubmitForm';
+
+const EditFieldModalStyle = css`
+.ant-modal-content {
+  border-radius: 16px;
+}
+
+.ant-modal-header {
+  border-radius: 16px 16px 0 0;
+}
+`;
+
+export interface EditFieldModalProps {
+  title?: string;
+  submitting?: boolean;
+  errorMsgs?: string[];
+  formRef: React.MutableRefObject<{
+    submit: () => (Promise<unknown> | undefined);
+  } | null>;
+  renderContent: () => React.ReactNode;
+}
+
+export function EditFieldModal(props: EditFieldModalProps) {
+  const { title, formRef: form, renderContent } = props;
+  const kit = useUIKit();
+  const { i18n } = useTranslation();
+  const {
+    submitting,
+    errorMsgs,
+    reset,
+    onSubmit,
+  } = useSubmitForm({
+    formRef: form,
+    onSubmitSuccess: popModal
+  });
+
+  const close = useCallback(()=> {
+    popModal();
+    reset();
+  }, [reset]);
+
+  return (
+    <kit.modal
+      className={EditFieldModalStyle}
+      title={title || i18n.t('dovetail.edit')}
+      confirmLoading={submitting}
+      onOk={onSubmit}
+      onCancel={close}
+      normal
+      destroyOnClose
+    >
+      {renderContent()}
+      <FormErrorAlert
+        style={{ marginTop: 16 }}
+        errorMsgs={errorMsgs}
+      />
+    </kit.modal>
+  );
+}
+
+export interface EditField {
+  modalProps: EditFieldModalProps;
+}
+
+export function EditField(props: EditField) {
+  const { modalProps } = props;
+  const kit = useUIKit();
+  const { i18n } = useTranslation();
+
+  return (
+    <kit.button
+      type="link"
+      onClick={() => {
+        pushModal({
+          component: EditFieldModal,
+          props: modalProps
+        });
+      }}
+    >{i18n.t('dovetail.edit')}</kit.button>
+  );
+}

--- a/packages/refine/src/components/FormErrorAlert/index.tsx
+++ b/packages/refine/src/components/FormErrorAlert/index.tsx
@@ -1,0 +1,35 @@
+import { useUIKit } from '@cloudtower/eagle';
+import { first } from 'lodash-es';
+import React from 'react';
+
+interface FormErrorAlertProps {
+  errorMsgs: string[];
+  style?: React.CSSProperties;
+  className?: string;
+}
+
+export function FormErrorAlert(props: FormErrorAlertProps) {
+  const { errorMsgs, style, className } = props;
+  const kit = useUIKit();
+
+  return errorMsgs.length ? (
+    <kit.alert
+      message={
+        errorMsgs.length > 1 ? (
+          <ul>
+            {errorMsgs.map((errorMsg, index) => (
+              <li key={errorMsg}>
+                {index + 1 + '. '} {errorMsg}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          first(errorMsgs)
+        )
+      }
+      type="error"
+      style={style}
+      className={className}
+    />
+  ) : null;
+}

--- a/packages/refine/src/components/ShowContent/ShowContent.tsx
+++ b/packages/refine/src/components/ShowContent/ShowContent.tsx
@@ -124,7 +124,7 @@ export const ShowContent = <Model extends ResourceModel>(props: Props<Model>) =>
     return fields.map(field => {
       let content;
       if (field.render) {
-        content = field.render(get(record, field.path), record);
+        content = field.render(get(record, field.path), record, field);
       } else {
         content = <span>{get(record, field.path)}</span>;
       }

--- a/packages/refine/src/components/ShowContent/fields.tsx
+++ b/packages/refine/src/components/ShowContent/fields.tsx
@@ -21,7 +21,7 @@ export type ShowField<Model extends ResourceModel> = {
   key: string;
   title: string;
   path: string[];
-  render?: (val: unknown, record: Model) => React.ReactElement | undefined;
+  render?: (val: unknown, record: Model, field: ShowField<Model>) => React.ReactElement | undefined;
 };
 
 export const ImageField = (): ShowField<WorkloadBaseModel> => {
@@ -40,8 +40,8 @@ export const ReplicaField = (): ShowField<WorkloadModel> => {
     key: 'Replicas',
     title: i18n.t('dovetail.replicas'),
     path: ['status', 'replicas'],
-    render: (_, record) => {
-      return <WorkloadReplicas record={record} />;
+    render: (_, record, field) => {
+      return <WorkloadReplicas record={record} field={field} editable />;
     },
   };
 };

--- a/packages/refine/src/components/YamlForm/index.tsx
+++ b/packages/refine/src/components/YamlForm/index.tsx
@@ -3,6 +3,7 @@ import { css } from '@linaria/core';
 import React, { useMemo, useCallback, useImperativeHandle } from 'react';
 import { useTranslation } from 'react-i18next';
 import ErrorContent from 'src/components/ErrorContent';
+import { FormErrorAlert } from 'src/components/FormErrorAlert';
 import FormLayout from 'src/components/FormLayout';
 import { YamlEditorComponent } from 'src/components/YamlEditor/YamlEditorComponent';
 import { BASE_INIT_VALUE } from 'src/constants/k8s';
@@ -104,22 +105,8 @@ const YamlForm = React.forwardRef<YamlFormHandler, YamlFormProps>(function YamlF
               </kit.form.Item>
               <kit.form.Item>
                 {mutationResult.error && (
-                  <kit.alert
-                    message={
-                      errorResponseBody ? (
-                        <ul>
-                          {responseErrors.map((error, index) => (
-                            <li key={error}>
-                              {responseErrors.length > 1 ? index + 1 + '. ' : ''}
-                              {error}
-                            </li>
-                          ))}
-                        </ul>
-                      ) : (
-                        mutationResult.error.message
-                      )
-                    }
-                    type="error"
+                  <FormErrorAlert
+                    errorMsgs={errorResponseBody ? responseErrors : [mutationResult.error.message]}
                     style={{ marginBottom: 16 }}
                   />
                 )}

--- a/packages/refine/src/hooks/useSubmitForm.ts
+++ b/packages/refine/src/hooks/useSubmitForm.ts
@@ -1,0 +1,51 @@
+import React, { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getCommonErrors, ErrorResponseBody } from 'src/utils/error';
+
+interface UseSubmitFormOptions {
+  formRef: React.MutableRefObject<{
+    submit: () => (Promise<unknown> | undefined);
+  } | null>;
+  onSubmitSuccess?: () => void;
+}
+
+export function useSubmitForm(options: UseSubmitFormOptions) {
+  const { formRef, onSubmitSuccess } = options;
+  const { i18n } = useTranslation();
+  const [submitting, setSubmitting] = useState(false);
+  const [errorMsgs, setErrorMsgs] = useState<string[]>([]);
+
+  const reset = useCallback(() => {
+    setSubmitting(false);
+    setErrorMsgs([]);
+  }, []);
+  const onSubmit = useCallback(async () => {
+    try {
+      setSubmitting(true);
+
+      await formRef.current?.submit();
+      onSubmitSuccess?.();
+      reset();
+    } catch (error: unknown) {
+      if (error instanceof Object) {
+        if ('response' in error && error.response instanceof Response) {
+          const response = error.response;
+          const body: ErrorResponseBody = await response.json();
+
+          setErrorMsgs(getCommonErrors(body, i18n));
+        } else if ('message' in error && typeof error.message === 'string') {
+          setErrorMsgs([error.message]);
+        }
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }, [formRef, i18n, reset, onSubmitSuccess]);
+
+  return {
+    submitting,
+    errorMsgs,
+    reset,
+    onSubmit,
+  };
+}

--- a/packages/refine/src/types/modal.d.ts
+++ b/packages/refine/src/types/modal.d.ts
@@ -1,8 +1,10 @@
 import { ModalType } from '@cloudtower/eagle';
+import { EditFieldModalProps } from 'src/components/EditField';
 import { FormModalProps } from 'src/components/FormModal';
 
 type ModalProps = {
   FormModal: FormModalProps;
+  EditFieldModal: EditFieldModalProps;
 };
 
 declare module '@cloudtower/eagle' {

--- a/packages/refine/src/utils/error.ts
+++ b/packages/refine/src/utils/error.ts
@@ -7,7 +7,7 @@ type Cause = {
   field?: string;
 };
 
-type ErrorResponse = {
+export type ErrorResponseBody = {
   message?: string;
   code?: number;
   reason?: string;
@@ -26,27 +26,27 @@ export function isNetworkError(errors?: Cause[]) {
 }
 
 export function getSubmitError(
-  errorResponse: ErrorResponse | undefined,
+  errorResponse: ErrorResponseBody | undefined,
   text: string,
   i18n: I18n
 ) {
   return !errorResponse ? i18n.t('dovetail.network_error') : text;
 }
 
-export function getCommonErrors(response: ErrorResponse, i18n: I18n) {
+export function getCommonErrors(responseBody: ErrorResponseBody, i18n: I18n) {
   if (
     !(
-      response?.message ||
-      response?.code ||
-      response?.reason ||
-      response?.details ||
-      response?.graphQLErrors
+      responseBody?.message ||
+      responseBody?.code ||
+      responseBody?.reason ||
+      responseBody?.details ||
+      responseBody?.graphQLErrors
     )
   ) {
     return [];
   }
 
-  const causes: Cause[] = response.details?.causes || response.graphQLErrors || [];
+  const causes: Cause[] = responseBody.details?.causes || responseBody.graphQLErrors || [];
 
   if (causes.length) {
     return causes.map(cause => {
@@ -88,7 +88,7 @@ export function getCommonErrors(response: ErrorResponse, i18n: I18n) {
 
   return [
     i18n.t(
-      [`error.${response.code}`, `error.${response.reason}`, response.message || ''],
+      [`error.${responseBody.code}`, `error.${responseBody.reason}`, responseBody.message || ''],
       { fallbackLng: '' }
     ),
   ];


### PR DESCRIPTION
<img width="1439" alt="image" src="https://github.com/webzard-io/dovetail-v2/assets/25414733/cf9d6907-dee7-46d5-95a2-72c4ed1ef7ba">

编辑副本数改为弹窗方式。

主要实现的组件有 EditFieldModal、WorkloadReplicasForm。

EditFieldModal 为通用的编辑字段模态框组件，支持传入自定义实现的表单组件。

WorkloadReplicasForm 为编辑副本数的表单组件，其将表单值状态都内聚在组件内部，以便在模态框关闭时销毁该组件来重置表单状态。