### PR TITLE
feat: change the data struct of detail props

### DIFF
--- a/packages/refine/src/components/DrawerShow/DrawerShow.tsx
+++ b/packages/refine/src/components/DrawerShow/DrawerShow.tsx
@@ -3,10 +3,10 @@ import { useNavigation, useParsed, useShow } from '@refinedev/core';
 import { Drawer } from 'antd';
 import React from 'react';
 import { ResourceModel } from '../../models';
-import { ShowField, ShowContent } from '../ShowContent';
+import { ShowConfig, ShowContent } from '../ShowContent';
 
 type Props<Model extends ResourceModel> = {
-  fieldGroups: ShowField<Model>[][];
+  showConfig: ShowConfig<Model>;
   formatter?: (r: Model) => Model;
 };
 

--- a/packages/refine/src/components/ImageNames/index.tsx
+++ b/packages/refine/src/components/ImageNames/index.tsx
@@ -12,8 +12,8 @@ export const ImageNames: React.FC<{ value: string[] }> = ({ value }) => {
   const { t } = useTranslation();
 
   return (
-    <div>
-      <div>{value[0]}</div>
+    <span>
+      <span>{value[0]}</span>
       {value.length > 1 && (
         <kit.tooltip
           title={
@@ -29,6 +29,6 @@ export const ImageNames: React.FC<{ value: string[] }> = ({ value }) => {
           </div>
         </kit.tooltip>
       )}
-    </div>
+    </span>
   );
 };

--- a/packages/refine/src/components/PageShow/PageShow.tsx
+++ b/packages/refine/src/components/PageShow/PageShow.tsx
@@ -2,10 +2,10 @@ import { useUIKit } from '@cloudtower/eagle';
 import { useParsed, useShow } from '@refinedev/core';
 import React from 'react';
 import { ResourceModel } from '../../models';
-import { ShowContent, ShowField } from '../ShowContent';
+import { ShowContent, ShowConfig } from '../ShowContent';
 
 type Props<Model extends ResourceModel> = {
-  fieldGroups: ShowField<Model>[][];
+  showConfig: ShowConfig<Model>;
   formatter?: (r: Model) => Model;
   Dropdown?: React.FC<{ record: Model }>;
 };

--- a/packages/refine/src/components/ResourceCRUD/ResourceCRUD.tsx
+++ b/packages/refine/src/components/ResourceCRUD/ResourceCRUD.tsx
@@ -26,7 +26,7 @@ export function ResourceCRUD(props: Props) {
             <Route path={`${urlPrefix}/${config.name}/show`}>
               <ResourceShow
                 formatter={config.formatter}
-                filedGroups={config.showFields?.() || []}
+                showConfig={config.showConfig?.() || {}}
                 Dropdown={config.Dropdown}
               />
             </Route>

--- a/packages/refine/src/components/ResourceCRUD/show/index.tsx
+++ b/packages/refine/src/components/ResourceCRUD/show/index.tsx
@@ -2,20 +2,20 @@ import { IResourceComponentsProps } from '@refinedev/core';
 import React from 'react';
 import { ResourceModel } from '../../../models';
 import { PageShow } from '../../PageShow';
-import { ShowField } from '../../ShowContent';
+import { ShowConfig } from '../../ShowContent';
 
 type Props<Model extends ResourceModel> = IResourceComponentsProps & {
   formatter?: (v: Model) => Model;
-  filedGroups: ShowField<Model>[][];
+  showConfig: ShowConfig<Model>;
   Dropdown?: React.FC<{ record: Model }>;
 };
 
 export function ResourceShow<Model extends ResourceModel>(props: Props<Model>) {
-  const { formatter, filedGroups, Dropdown } = props;
+  const { formatter, showConfig, Dropdown } = props;
 
   return (
     <PageShow<Model>
-      fieldGroups={filedGroups}
+      showConfig={showConfig}
       formatter={formatter}
       Dropdown={Dropdown}
     />

--- a/packages/refine/src/components/ShowContent/fields.tsx
+++ b/packages/refine/src/components/ShowContent/fields.tsx
@@ -21,15 +21,35 @@ export type ShowField<Model extends ResourceModel> = {
   key: string;
   title: string;
   path: string[];
+  labelWidth?: string;
+  col?: number;
   render?: (val: unknown, record: Model, field: ShowField<Model>) => React.ReactElement | undefined;
+  renderContent?: (val: unknown, record: Model, field: ShowField<Model>) => React.ReactElement | undefined;
 };
 
-export const ImageField = (): ShowField<WorkloadBaseModel> => {
+export type ShowTabField<Model extends ResourceModel> = {
+  key: string;
+  title: string;
+  path: string[];
+  renderContent?: (val: unknown, record: Model, field: ShowTabField<Model>) => React.ReactElement | undefined;
+};
+
+export interface ShowConfig<Model extends ResourceModel = ResourceModel> {
+  title?: string;
+  descriptions?: ShowField<Model>[];
+  groups?: {
+    fields: ShowField<Model>[];
+  }[];
+  tabs?: ShowTabField<Model>[];
+}
+
+export const ImageField = <Model extends WorkloadBaseModel>(): ShowField<Model> => {
   return {
     key: 'Image',
     title: i18n.t('dovetail.image'),
     path: ['imageNames'],
-    render(value) {
+    col: 12,
+    renderContent(value) {
       return <ImageNames value={value as string[]} />;
     },
   };
@@ -40,29 +60,29 @@ export const ReplicaField = (): ShowField<WorkloadModel> => {
     key: 'Replicas',
     title: i18n.t('dovetail.replicas'),
     path: ['status', 'replicas'],
-    render: (_, record, field) => {
-      return <WorkloadReplicas record={record} field={field} editable />;
+    renderContent: (_, record, field) => {
+      return <WorkloadReplicas record={record} label={field.title} editable />;
     },
   };
 };
 
-export const ConditionsField = (): ShowField<ResourceModel> => {
+export const ConditionsField = <Model extends ResourceModel>(): ShowTabField<Model> => {
   return {
     key: 'Conditions',
     title: i18n.t('dovetail.condition'),
     path: ['status', 'conditions'],
-    render: value => {
+    renderContent: value => {
       return <ConditionsTable conditions={value as Condition[]} />;
     },
   };
 };
 
-export const PodsField = (): ShowField<WorkloadModel> => {
+export const PodsField = <Model extends WorkloadBaseModel>(): ShowTabField<Model> => {
   return {
     key: 'pods',
     title: 'Pods',
     path: [],
-    render: (_, record) => {
+    renderContent: (_, record) => {
       return (
         <WorkloadPodsTable
           selector={
@@ -76,12 +96,12 @@ export const PodsField = (): ShowField<WorkloadModel> => {
   };
 };
 
-export const JobsField = (): ShowField<JobModel | CronJobModel> => {
+export const JobsField = <Model extends JobModel | CronJobModel>(): ShowTabField<Model> => {
   return {
     key: 'jobs',
     title: 'Jobs',
     path: [],
-    render: (_, record) => {
+    renderContent: (_, record) => {
       return (
         <CronjobJobsTable
           owner={{
@@ -102,7 +122,7 @@ export const DataField = (): ShowField<ResourceModel> => {
     key: 'data',
     title: i18n.t('dovetail.data'),
     path: ['data'],
-    render: val => {
+    renderContent: val => {
       return <KeyValue value={val as Record<string, string>} />;
     },
   };
@@ -113,7 +133,7 @@ export const SecretDataField = (): ShowField<ResourceModel> => {
     key: 'data',
     title: i18n.t('dovetail.data'),
     path: ['data'],
-    render: val => {
+    renderContent: val => {
       const decodeVal: Record<string, string> = {};
       for (const key in val as Record<string, string>) {
         decodeVal[key] = atob((val as Record<string, string>)[key]);
@@ -128,7 +148,8 @@ export const StartTimeField = (): ShowField<JobModel> => {
     key: 'started',
     title: i18n.t('dovetail.started'),
     path: ['status', 'startTime'],
-    render(value) {
+    col: 12,
+    renderContent(value) {
       return <Time date={value as string} />;
     },
   };
@@ -158,12 +179,12 @@ export const SessionAffinityField = (): ShowField<ResourceModel> => {
   };
 };
 
-export const ServicePodsField = (): ShowField<ResourceModel> => {
+export const ServicePodsField = <Model extends ResourceModel>(): ShowTabField<Model> => {
   return {
     key: 'pods',
     title: 'Pods',
     path: [],
-    render: (_, record) => {
+    renderContent: (_, record) => {
       return (
         <WorkloadPodsTable
           selector={

--- a/packages/refine/src/components/WorkloadReplicas/index.tsx
+++ b/packages/refine/src/components/WorkloadReplicas/index.tsx
@@ -4,7 +4,6 @@ import { useResource, useUpdate } from '@refinedev/core';
 import { get } from 'lodash-es';
 import React, { useState, useCallback, useImperativeHandle, useRef } from 'react';
 import { EditField } from 'src/components/EditField';
-import { ShowField } from 'src/components/ShowContent';
 import { WorkloadModel } from '../../models';
 import { pruneBeforeEdit } from '../../utils/k8s';
 
@@ -66,11 +65,11 @@ const WorkloadReplicasForm = React.forwardRef<WorkloadReplicasFormHandler, Workl
 
 export interface WorkloadReplicasProps {
   record: WorkloadModel;
-  field: ShowField<WorkloadModel>;
+  label?: string;
   editable?: boolean;
 }
 
-export function WorkloadReplicas({ record, field, editable }: WorkloadReplicasProps) {
+export function WorkloadReplicas({ record, label, editable }: WorkloadReplicasProps) {
   const formRef = useRef<WorkloadReplicasFormHandler | null>(null);
 
   const readyReplicas =
@@ -94,7 +93,7 @@ export function WorkloadReplicas({ record, field, editable }: WorkloadReplicasPr
                     ref={formRef}
                     defaultValue={currentReplicas}
                     record={record}
-                    label={field.title}
+                    label={label || ''}
                   />
                 );
               }

--- a/packages/refine/src/pages/configmaps/index.ts
+++ b/packages/refine/src/pages/configmaps/index.ts
@@ -11,5 +11,7 @@ export const ConfigMapConfig: ResourceConfig<ResourceModel> = {
   parent: RESOURCE_GROUP.STORAGE,
   label: 'ConfigMaps',
   columns: () => [AgeColumnRenderer()],
-  showFields: () => [[], [], [DataField()]],
+  showConfig: () => ({
+    tabs: [DataField()],
+  }),
 };

--- a/packages/refine/src/pages/cronjobs/show/index.tsx
+++ b/packages/refine/src/pages/cronjobs/show/index.tsx
@@ -8,7 +8,12 @@ import { CronJobModel } from '../../../models';
 export const CronJobShow: React.FC<IResourceComponentsProps> = () => {
   return (
     <PageShow<CronJobModel>
-      fieldGroups={[[], [ImageField()], [JobsField()]]}
+      showConfig={{
+        groups: [{
+          fields: [ImageField()]
+        }],
+        tabs: [JobsField()],
+      }}
       Dropdown={CronJobDropdown}
     />
   );

--- a/packages/refine/src/pages/daemonsets/show/index.tsx
+++ b/packages/refine/src/pages/daemonsets/show/index.tsx
@@ -12,7 +12,12 @@ import { WorkloadModel } from '../../../models';
 export const DaemonSetShow: React.FC<IResourceComponentsProps> = () => {
   return (
     <PageShow<WorkloadModel>
-      fieldGroups={[[], [ImageField()], [PodsField(), ConditionsField()]]}
+      showConfig={{
+        groups: [{
+          fields: [ImageField()]
+        }],
+        tabs: [PodsField(), ConditionsField()],
+      }}
       Dropdown={WorkloadDropdown}
     />
   );

--- a/packages/refine/src/pages/deployments/show/index.tsx
+++ b/packages/refine/src/pages/deployments/show/index.tsx
@@ -11,14 +11,14 @@ import { WorkloadDropdown } from '../../../components/WorkloadDropdown';
 import { WorkloadModel } from '../../../models';
 
 export const DeploymentShow: React.FC<IResourceComponentsProps> = () => {
-
   return (
     <PageShow<WorkloadModel>
-      fieldGroups={[
-        [],
-        [ImageField(), ReplicaField()],
-        [PodsField(), ConditionsField()],
-      ]}
+      showConfig={{
+        groups: [{
+          fields: [ImageField(), ReplicaField()]
+        }],
+        tabs: [PodsField(), ConditionsField()],
+      }}
       Dropdown={WorkloadDropdown}
     />
   );

--- a/packages/refine/src/pages/jobs/index.ts
+++ b/packages/refine/src/pages/jobs/index.ts
@@ -5,7 +5,6 @@ import {
   ConditionsField,
   ImageField,
   PodsField,
-  ShowField,
   StartTimeField,
 } from '../../components/ShowContent';
 import { JOB_INIT_VALUE } from '../../constants/k8s';
@@ -34,12 +33,13 @@ export const JobConfig: ResourceConfig<JobModel> = {
       DurationColumnRenderer(),
       AgeColumnRenderer(),
     ] as Column<JobModel>[],
-  showFields: () =>
-    [
-      [],
-      [StartTimeField(), ImageField()],
-      [PodsField(), ConditionsField()],
-    ] as ShowField<JobModel>[][],
+  showConfig: () => ({
+    descriptions: [],
+    groups: [{
+      fields: [StartTimeField(), ImageField()],
+    }],
+    tabs: [PodsField(), ConditionsField()]
+  }),
   initValue: JOB_INIT_VALUE,
   Dropdown: K8sDropdown,
   formType: FormType.MODAL

--- a/packages/refine/src/pages/pods/show/index.tsx
+++ b/packages/refine/src/pages/pods/show/index.tsx
@@ -12,36 +12,37 @@ export const PodShow: React.FC<IResourceComponentsProps> = () => {
 
   return (
     <PageShow<PodModel>
-      fieldGroups={[
-        [],
-        [
-          {
-            key: 'podIp',
-            title: 'Pod IP',
-            path: ['status', 'podIP'],
-          },
-          {
-            key: 'Workload',
-            title: i18n.t('dovetail.workload'),
-            path: ['metadata', 'ownerReferences', '0', 'name'],
-          },
-          {
-            key: 'Node',
-            title: i18n.t('dovetail.node_name'),
-            path: ['spec', 'nodeName'],
-          },
-          {
-            key: 'readyDisplay',
-            title: 'Ready',
-            path: ['readyDisplay'],
-          },
-        ],
-        [
+      showConfig={{
+        groups: [{
+          fields: [
+            {
+              key: 'podIp',
+              title: 'Pod IP',
+              path: ['status', 'podIP'],
+            },
+            {
+              key: 'Workload',
+              title: i18n.t('dovetail.workload'),
+              path: ['metadata', 'ownerReferences', '0', 'name'],
+            },
+            {
+              key: 'Node',
+              title: i18n.t('dovetail.node_name'),
+              path: ['spec', 'nodeName'],
+            },
+            {
+              key: 'readyDisplay',
+              title: 'Ready',
+              path: ['readyDisplay'],
+            },
+          ]
+        }],
+        tabs: [
           {
             key: 'container',
             title: i18n.t('dovetail.container'),
             path: [],
-            render: (_, record) => {
+            renderContent: (_, record) => {
               return (
                 <PodContainersTable
                   containerStatuses={record.status?.containerStatuses || []}
@@ -55,12 +56,12 @@ export const PodShow: React.FC<IResourceComponentsProps> = () => {
             key: 'log',
             title: i18n.t('dovetail.log'),
             path: [],
-            render: (_, record) => {
+            renderContent: (_, record) => {
               return <PodLog pod={record} />;
             },
           },
         ],
-      ]}
+      }}
     />
   );
 };

--- a/packages/refine/src/pages/secrets/index.ts
+++ b/packages/refine/src/pages/secrets/index.ts
@@ -11,5 +11,7 @@ export const SecretsConfig: ResourceConfig<ResourceModel> = {
   parent: RESOURCE_GROUP.STORAGE,
   label: 'Secrets',
   columns: () => [AgeColumnRenderer()],
-  showFields: () => [[], [], [SecretDataField()]],
+  showConfig: () => ({
+    tabs: [SecretDataField()]
+  }),
 };

--- a/packages/refine/src/pages/services/index.ts
+++ b/packages/refine/src/pages/services/index.ts
@@ -21,10 +21,11 @@ export const ServicesConfig: ResourceConfig<ResourceModel> = {
   label: 'Services',
   parent: RESOURCE_GROUP.NETWORK,
   columns: () => [ServiceTypeColumnRenderer(), AgeColumnRenderer()],
-  showFields: () => [
-    [],
-    [ServiceTypeField(), ClusterIpField(), SessionAffinityField()],
-    [ServicePodsField(), ConditionsField()],
-  ],
+  showConfig: () => ({
+    groups: [{
+      fields: [ServiceTypeField(), ClusterIpField(), SessionAffinityField()],
+    }],
+    tabs: [ServicePodsField(), ConditionsField()],
+  }),
   initValue: SERVICE_INIT_VALUE,
 };

--- a/packages/refine/src/pages/statefulsets/show/index.tsx
+++ b/packages/refine/src/pages/statefulsets/show/index.tsx
@@ -13,7 +13,12 @@ import { WorkloadModel } from '../../../models';
 export const StatefulSetShow: React.FC<IResourceComponentsProps> = () => {
   return (
     <PageShow<WorkloadModel>
-      fieldGroups={[[], [ImageField(), ReplicaField()], [PodsField(), ConditionsField()]]}
+      showConfig={{
+        groups: [{
+          fields: [ImageField(), ReplicaField()]
+        }],
+        tabs: [PodsField(), ConditionsField()]
+      }}
       Dropdown={WorkloadDropdown}
     />
   );

--- a/packages/refine/src/types/resource.ts
+++ b/packages/refine/src/types/resource.ts
@@ -1,5 +1,5 @@
 import { FormModalProps } from 'src/components/FormModal';
-import { ShowField } from '../components/ShowContent';
+import { ShowConfig } from '../components/ShowContent';
 import { Column } from '../components/Table';
 import { ResourceModel } from '../models';
 
@@ -27,7 +27,7 @@ export type ResourceConfig<Model extends ResourceModel = ResourceModel> = {
   formatter?: (v: Model) => Model;
   initValue?: Record<string, unknown>;
   columns?: () => Column<Model>[];
-  showFields?: () => ShowField<Model>[][];
+  showConfig?: () => ShowConfig<Model>;
   Dropdown?: React.FC<{ record: Model }>;
   formType?: FormType;
   FormModal?: React.FC<FormModalProps>;


### PR DESCRIPTION
修改详情页字段数据结构。

```ts
export type ShowField<Model extends ResourceModel> = {
  key: string;
  title: string;
  path: string[];
  labelWidth?: string;
  col?: number;
  render?: (val: unknown, record: Model) => React.ReactElement | undefined;
  renderContent?: (val: unknown, record: Model) => React.ReactElement | undefined;
};

export type ShowTabField<Model extends ResourceModel> = {
  key: string;
  title: string;
  path: string[];
  renderContent?: (val: unknown, record: Model) => React.ReactElement | undefined;
};

export interface Detail<Model extends ResourceModel = ResourceModel> {
  title?: string;
  descriptions?: ShowField<Model>[];
  groups?: {
    fields: ShowField<Model>[];
  }[];
  tabs?: ShowTabField<Model>[];
}
```

详情页目前分为 descriptions, groups, tabs 三个区域。

descriptions 可放置多个字段。

可添加多个 groups，每个 group 可放置多个字段，字段按照数组中的顺序进行排序。可通过 col 来设置字段所占的栅格数，每行有 24 栅格。设置 labelWidth 修改标签宽度。

tabs 设置每个 tab 中放置的内容，一般用来放置比较大块的内容，比如表格。

目前样式还没修改（比如每个 group 分隔的样式），等后续调整布局时统一修改。

![image](https://github.com/webzard-io/dovetail-v2/assets/25414733/c761f6ea-127f-4a4d-a78e-6d63e75716d5)


