### PR TITLE
use stateDisplay to get state in ShowContent

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/src/components/ShowContent/ShowContent.tsx
+++ b/packages/refine/src/components/ShowContent/ShowContent.tsx
@@ -9,6 +9,7 @@ import K8sDropdown from 'src/components/K8sDropdown';
 import { KeyValueData } from 'src/components/KeyValueData';
 import MonacoYamlEditor from 'src/components/YamlEditor/MonacoYamlEditor';
 import useK8sYamlEditor from 'src/hooks/useK8sYamlEditor';
+import { WorkloadState } from '../../constants';
 import { useGlobalStore } from '../../hooks';
 import { ResourceModel } from '../../models';
 import { StateTag } from '../StateTag';
@@ -168,13 +169,15 @@ export const ShowContent = <Model extends ResourceModel>(props: Props<Model>) =>
     },
   ];
 
-  const state = get(record, ['status', 'phase']);
+  const stateDisplay = get(record, 'stateDisplay') as WorkloadState;
   const topBar = (
     <kit.space className={TopBarStyle}>
       <div>
         <span className={Typo.Display.d2_bold_title}>{resource?.meta?.kind}: </span>
         <span className={Typo.Label.l1_regular}>{record?.metadata?.name}</span>
-        {state ? <StateTag className={StateTagStyle} state={state} /> : undefined}
+        {stateDisplay ? (
+          <StateTag className={StateTagStyle} state={stateDisplay} />
+        ) : undefined}
       </div>
       <kit.space>
         <kit.radioGroup value={mode} onChange={e => setMode(e.target.value)}>

--- a/packages/refine/src/components/index.ts
+++ b/packages/refine/src/components/index.ts
@@ -35,3 +35,4 @@ export * from './NamespacesFilter';
 export * from './Tags';
 export * from './PodLog';
 export * from './FormModal';
+export * from './NetworkPolicyRulesTable';


### PR DESCRIPTION
之前用status.phase 判断详情页中是否可以显示状态，但这样不准确，不是所有有状态的资源都是通过status.phase获取状态的。所以用 stateDisplay 来判断。stateDisplay 是 Model 中自定义的状态。
![截屏2024-02-18 16 10 47](https://github.com/webzard-io/dovetail-v2/assets/12260952/2cb38570-b074-4fa7-bb70-1b429c8d73c1)
