### PR TITLE
pass i18n to columnRendereer and showField

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.0.20",
+  "version": "0.0.30",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/src/App.tsx
+++ b/packages/refine/src/App.tsx
@@ -1,7 +1,7 @@
 import { createBrowserHistory } from 'history';
 import { GlobalStore } from 'k8s-api-provider';
 import React, { useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
+import { I18nextProvider } from 'react-i18next';
 import { Route, Router } from 'react-router-dom';
 import { Layout } from './components';
 import {
@@ -11,6 +11,7 @@ import {
   POD_INIT_VALUE,
 } from './constants/k8s';
 import { Dovetail } from './Dovetail';
+import i18n from './i18n';
 import { ConfigMapConfig } from './pages/configmaps';
 import { CronJobForm, CronJobList, CronJobShow } from './pages/cronjobs';
 import { DaemonSetForm, DaemonSetList, DaemonSetShow } from './pages/daemonsets';
@@ -26,7 +27,6 @@ import { ProviderPlugins } from './plugins';
 import { RESOURCE_GROUP, ResourceConfig, FormType } from './types';
 
 function App() {
-  const { t } = useTranslation();
   const histroy = createBrowserHistory();
 
   const resourcesConfig = useMemo(() => {
@@ -86,26 +86,6 @@ function App() {
     ];
   }, []);
 
-  const refineResources = useMemo(() => {
-    return [
-      {
-        name: t('dovetail.cluster'),
-        identifier: RESOURCE_GROUP.CLUSTER,
-      },
-      {
-        name: t('dovetail.workload'),
-        identifier: RESOURCE_GROUP.WORKLOAD,
-      },
-      {
-        name: t('dovetail.network'),
-        identifier: RESOURCE_GROUP.NETWORK,
-      },
-      {
-        name: t('dovetail.storage'),
-        identifier: RESOURCE_GROUP.STORAGE,
-      },
-    ];
-  }, [t]);
   const globalStore = useMemo(() => {
     return new GlobalStore(
       {
@@ -117,70 +97,71 @@ function App() {
     );
   }, []);
   return (
-    <Dovetail
-      resourcesConfig={resourcesConfig as ResourceConfig[]}
-      refineResources={refineResources}
-      Layout={Layout}
-      history={histroy}
-      globalStore={globalStore}
-    >
-      <Router history={histroy}>
-        <Route path="/cronjobs" exact>
-          <CronJobList />
-        </Route>
-        <Route path="/cronjobs/show">
-          <CronJobShow />
-        </Route>
-        <Route path="/cronjobs/create">
-          <CronJobForm />
-        </Route>
-        <Route path="/cronjobs/edit">
-          <CronJobForm />
-        </Route>
-        <Route path="/daemonsets" exact>
-          <DaemonSetList />
-        </Route>
-        <Route path="/daemonsets/show">
-          <DaemonSetShow />
-        </Route>
-        <Route path="/daemonsets/create">
-          <DaemonSetForm />
-        </Route>
-        <Route path="/daemonsets/edit">
-          <DaemonSetForm />
-        </Route>
-        <Route path="/deployments" exact>
-          <DeploymentList />
-        </Route>
-        <Route path="/deployments/show">
-          <DeploymentShow />
-        </Route>
-        <Route path="/statefulsets" exact>
-          <StatefulSetList />
-        </Route>
-        <Route path="/statefulsets/show">
-          <StatefulSetShow />
-        </Route>
-        <Route path="/statefulsets/create">
-          <StatefulSetForm />
-        </Route>
-        <Route path="/statefulsets/edit">
-          <StatefulSetForm />
-        </Route>
-        <Route path="/pods" exact>
-          <PodList />
-        </Route>
-        <Route path="/pods/show">
-          <PodShow />
-        </Route>
-        <Route path="/pods/create">
-          <PodForm />
-        </Route>
-        <Route path="/pods/edit">
-          <PodForm />
-        </Route>
-      </Router>
-    </Dovetail>
+    <I18nextProvider i18n={i18n}>
+      <Dovetail
+        resourcesConfig={resourcesConfig as ResourceConfig[]}
+        Layout={Layout}
+        history={histroy}
+        globalStore={globalStore}
+      >
+        <Router history={histroy}>
+          <Route path="/cronjobs" exact>
+            <CronJobList />
+          </Route>
+          <Route path="/cronjobs/show">
+            <CronJobShow />
+          </Route>
+          <Route path="/cronjobs/create">
+            <CronJobForm />
+          </Route>
+          <Route path="/cronjobs/edit">
+            <CronJobForm />
+          </Route>
+          <Route path="/daemonsets" exact>
+            <DaemonSetList />
+          </Route>
+          <Route path="/daemonsets/show">
+            <DaemonSetShow />
+          </Route>
+          <Route path="/daemonsets/create">
+            <DaemonSetForm />
+          </Route>
+          <Route path="/daemonsets/edit">
+            <DaemonSetForm />
+          </Route>
+          <Route path="/deployments" exact>
+            <DeploymentList />
+          </Route>
+          <Route path="/deployments/show">
+            <DeploymentShow />
+          </Route>
+          <Route path="/statefulsets" exact>
+            <StatefulSetList />
+          </Route>
+          <Route path="/statefulsets/show">
+            <StatefulSetShow />
+          </Route>
+          <Route path="/statefulsets/create">
+            <StatefulSetForm />
+          </Route>
+          <Route path="/statefulsets/edit">
+            <StatefulSetForm />
+          </Route>
+          <Route path="/pods" exact>
+            <PodList />
+          </Route>
+          <Route path="/pods/show">
+            <PodShow />
+          </Route>
+          <Route path="/pods/create">
+            <PodForm />
+          </Route>
+          <Route path="/pods/edit">
+            <PodForm />
+          </Route>
+        </Router>
+      </Dovetail>
+    </I18nextProvider>
   );
 }
 

--- a/packages/refine/src/Dovetail.tsx
+++ b/packages/refine/src/Dovetail.tsx
@@ -1,11 +1,7 @@
 import { KitStoreProvider, ModalStack } from '@cloudtower/eagle';
-import { Refine, ResourceProps } from '@refinedev/core';
+import { Refine } from '@refinedev/core';
 import { History } from 'history';
-import {
-  dataProvider,
-  liveProvider,
-  GlobalStore,
-} from 'k8s-api-provider';
+import { dataProvider, liveProvider, GlobalStore } from 'k8s-api-provider';
 import { keyBy } from 'lodash-es';
 import React, { useMemo } from 'react';
 import { Router } from 'react-router-dom';
@@ -13,17 +9,14 @@ import ConfigsContext from 'src/contexts/configs';
 import { ResourceCRUD } from './components/ResourceCRUD';
 import GlobalStoreContext from './contexts/global-store';
 import { routerProvider } from './providers/router-provider';
-import './i18n';
+import { ResourceConfig } from './types';
 
 import './styles.css';
-
-import { ResourceConfig } from './types';
 
 type Props = {
   resourcesConfig: ResourceConfig[];
   useHashUrl?: boolean;
   urlPrefix?: string;
-  refineResources?: ResourceProps[];
   Layout?: React.FC<unknown>;
   history: History;
   globalStore: GlobalStore;

--- a/packages/refine/src/components/CronjobJobsTable/index.tsx
+++ b/packages/refine/src/components/CronjobJobsTable/index.tsx
@@ -3,6 +3,7 @@ import { css } from '@linaria/core';
 import { useList } from '@refinedev/core';
 import { OwnerReference } from 'kubernetes-types/meta/v1';
 import React, { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   AgeColumnRenderer,
   CompletionsCountColumnRenderer,
@@ -38,6 +39,7 @@ function matchOwner(
 export const CronjobJobsTable: React.FC<{
   owner?: OwnerReference & { namespace: string };
 }> = ({ owner }) => {
+  const { i18n } = useTranslation();
   const kit = useUIKit();
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
   const [currentPage, setCurrentPage] = useState<number>(1);
@@ -54,13 +56,13 @@ export const CronjobJobsTable: React.FC<{
   }, [data?.data, owner]);
 
   const columns: Column<CronJobModel>[] = [
-    NameColumnRenderer('jobs'),
-    StateDisplayColumnRenderer(),
-    NameSpaceColumnRenderer(),
-    WorkloadImageColumnRenderer(),
-    CompletionsCountColumnRenderer(),
-    DurationColumnRenderer(),
-    AgeColumnRenderer(),
+    NameColumnRenderer(i18n, 'jobs'),
+    StateDisplayColumnRenderer(i18n),
+    NameSpaceColumnRenderer(i18n),
+    WorkloadImageColumnRenderer(i18n),
+    CompletionsCountColumnRenderer(i18n),
+    DurationColumnRenderer(i18n),
+    AgeColumnRenderer(i18n),
   ];
 
   return (

--- a/packages/refine/src/components/EventsTable/EventsTable.tsx
+++ b/packages/refine/src/components/EventsTable/EventsTable.tsx
@@ -21,7 +21,7 @@ export const EventsTable: React.FC = ({}) => {
 
   const columns = useMemo(
     () => [
-      NameSpaceColumnRenderer(),
+      NameSpaceColumnRenderer(i18n),
       {
         key: 'type',
         display: true,
@@ -54,7 +54,7 @@ export const EventsTable: React.FC = ({}) => {
         sortable: true,
         sorter: CommonSorter(['note']),
       },
-      AgeColumnRenderer(),
+      AgeColumnRenderer(i18n),
     ],
     [i18n]
   );

--- a/packages/refine/src/components/FormModal/index.tsx
+++ b/packages/refine/src/components/FormModal/index.tsx
@@ -2,7 +2,7 @@ import { CloseCircleFilled } from '@ant-design/icons';
 import { useUIKit, popModal } from '@cloudtower/eagle';
 import { css } from '@linaria/core';
 import { useResource } from '@refinedev/core';
-import React, { useState, useContext, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useContext, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import YamlForm, { YamlFormProps } from 'src/components/YamlForm';
 import ConfigsContext from 'src/contexts/configs';

--- a/packages/refine/src/components/ResourceCRUD/list/index.tsx
+++ b/packages/refine/src/components/ResourceCRUD/list/index.tsx
@@ -1,5 +1,6 @@
 import { IResourceComponentsProps } from '@refinedev/core';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { useEagleTable } from '../../../hooks/useEagleTable';
 import { NameColumnRenderer } from '../../../hooks/useEagleTable/columns';
 import { ResourceModel } from '../../../models';
@@ -14,9 +15,10 @@ type Props<Model extends ResourceModel> = IResourceComponentsProps & {
 
 export function ResourceList<Model extends ResourceModel>(props: Props<Model>) {
   const { formatter, name, columns, Dropdown } = props;
+  const { i18n } = useTranslation();
   const { tableProps, selectedKeys } = useEagleTable<Model>({
     useTableParams: {},
-    columns: [NameColumnRenderer(), ...columns],
+    columns: [NameColumnRenderer(i18n), ...columns],
     tableProps: {
       currentSize: 10,
     },
@@ -25,10 +27,6 @@ export function ResourceList<Model extends ResourceModel>(props: Props<Model>) {
   });
 
   return (
-    <ListPage
-      title={name || ''}
-      selectedKeys={selectedKeys}
-      tableProps={tableProps}
-    />
+    <ListPage title={name || ''} selectedKeys={selectedKeys} tableProps={tableProps} />
   );
 }

--- a/packages/refine/src/components/ShowContent/fields.tsx
+++ b/packages/refine/src/components/ShowContent/fields.tsx
@@ -1,6 +1,6 @@
+import { i18n as I18nType } from 'i18next';
 import { Condition } from 'kubernetes-types/meta/v1';
 import React from 'react';
-import i18n from '../../i18n';
 import {
   JobModel,
   ResourceModel,
@@ -58,7 +58,9 @@ export interface ShowConfig<Model extends ResourceModel = ResourceModel> {
   tabs?: ShowTabField<Model>[];
 }
 
-export const ImageField = <Model extends WorkloadBaseModel>(): ShowField<Model> => {
+export const ImageField = <Model extends WorkloadBaseModel>(
+  i18n: I18nType
+): ShowField<Model> => {
   return {
     key: 'Image',
     title: i18n.t('dovetail.image'),
@@ -70,7 +72,7 @@ export const ImageField = <Model extends WorkloadBaseModel>(): ShowField<Model> 
   };
 };
 
-export const ReplicaField = (): ShowField<WorkloadModel> => {
+export const ReplicaField = (i18n: I18nType): ShowField<WorkloadModel> => {
   return {
     key: 'Replicas',
     title: i18n.t('dovetail.replicas'),
@@ -81,7 +83,9 @@ export const ReplicaField = (): ShowField<WorkloadModel> => {
   };
 };
 
-export const ConditionsField = <Model extends ResourceModel>(): ShowTabField<Model> => {
+export const ConditionsField = <Model extends ResourceModel>(
+  i18n: I18nType
+): ShowTabField<Model> => {
   return {
     key: 'Conditions',
     title: i18n.t('dovetail.condition'),
@@ -135,7 +139,7 @@ export const JobsField = <
   };
 };
 
-export const DataField = (): ShowField<ResourceModel> => {
+export const DataField = (i18n: I18nType): ShowField<ResourceModel> => {
   return {
     key: 'data',
     title: i18n.t('dovetail.data'),
@@ -146,7 +150,7 @@ export const DataField = (): ShowField<ResourceModel> => {
   };
 };
 
-export const SecretDataField = (): ShowField<ResourceModel> => {
+export const SecretDataField = (i18n: I18nType): ShowField<ResourceModel> => {
   return {
     key: 'data',
     title: i18n.t('dovetail.data'),
@@ -161,7 +165,7 @@ export const SecretDataField = (): ShowField<ResourceModel> => {
   };
 };
 
-export const StartTimeField = (): ShowField<JobModel> => {
+export const StartTimeField = (i18n: I18nType): ShowField<JobModel> => {
   return {
     key: 'started',
     title: i18n.t('dovetail.started'),
@@ -173,7 +177,7 @@ export const StartTimeField = (): ShowField<JobModel> => {
   };
 };
 
-export const ServiceTypeField = (): ShowField<ResourceModel> => {
+export const ServiceTypeField = (i18n: I18nType): ShowField<ResourceModel> => {
   return {
     key: 'type',
     title: i18n.t('dovetail.type'),
@@ -181,7 +185,7 @@ export const ServiceTypeField = (): ShowField<ResourceModel> => {
   };
 };
 
-export const ClusterIpField = (): ShowField<ResourceModel> => {
+export const ClusterIpField = (i18n: I18nType): ShowField<ResourceModel> => {
   return {
     key: 'clusterIp',
     title: i18n.t('dovetail.clusterIp'),
@@ -189,7 +193,7 @@ export const ClusterIpField = (): ShowField<ResourceModel> => {
   };
 };
 
-export const SessionAffinityField = (): ShowField<ResourceModel> => {
+export const SessionAffinityField = (i18n: I18nType): ShowField<ResourceModel> => {
   return {
     key: 'clusterIp',
     title: i18n.t('dovetail.sessionAffinity'),
@@ -216,9 +220,9 @@ export const ServicePodsField = <Model extends ResourceModel>(): ShowTabField<Mo
   };
 };
 
-export const IngressRulesTableTabField = <
-  Model extends IngressModel,
->(): ShowTabField<Model> => {
+export const IngressRulesTableTabField = <Model extends IngressModel>(
+  i18n: I18nType
+): ShowTabField<Model> => {
   return {
     key: 'rules',
     title: i18n.t('dovetail.rule'),
@@ -229,9 +233,9 @@ export const IngressRulesTableTabField = <
   };
 };
 
-export const EventsTableTabField = <
-  Model extends ResourceModel,
->(): ShowTabField<Model> => {
+export const EventsTableTabField = <Model extends ResourceModel>(
+  i18n: I18nType
+): ShowTabField<Model> => {
   return {
     key: 'event',
     title: i18n.t('dovetail.event'),

--- a/packages/refine/src/components/WorkloadPodsTable/WorkloadPodsTable.tsx
+++ b/packages/refine/src/components/WorkloadPodsTable/WorkloadPodsTable.tsx
@@ -3,6 +3,7 @@ import { css } from '@linaria/core';
 import { useList } from '@refinedev/core';
 import { LabelSelector } from 'kubernetes-types/meta/v1';
 import React, { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { matchSelector } from 'src/utils/match-selector';
 import {
   NameColumnRenderer,
@@ -24,6 +25,7 @@ export const WorkloadPodsTable: React.FC<WorkloadPodsTableProps> = ({
   selector,
   hideToolbar,
 }) => {
+  const { i18n } = useTranslation();
   const kit = useUIKit();
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
   const [currentPage, setCurrentPage] = useState<number>(1);
@@ -43,11 +45,11 @@ export const WorkloadPodsTable: React.FC<WorkloadPodsTableProps> = ({
   }, [data?.data, selector]);
 
   const columns: Column<PodModel>[] = [
-    StateDisplayColumnRenderer(),
-    NameColumnRenderer('pods'),
-    NodeNameColumnRenderer(),
-    WorkloadImageColumnRenderer(),
-    RestartCountColumnRenderer(),
+    StateDisplayColumnRenderer(i18n),
+    NameColumnRenderer(i18n, 'pods'),
+    NodeNameColumnRenderer(i18n),
+    WorkloadImageColumnRenderer(i18n),
+    RestartCountColumnRenderer(i18n),
   ];
 
   return (
@@ -58,11 +60,9 @@ export const WorkloadPodsTable: React.FC<WorkloadPodsTableProps> = ({
         vertical-align: top;
       `}
     >
-      {
-        hideToolbar ? null : (
-          <TableToolBar title="" selectedKeys={selectedKeys} hideCreate />
-        )
-      }
+      {hideToolbar ? null : (
+        <TableToolBar title="" selectedKeys={selectedKeys} hideCreate />
+      )}
       <Table
         tableKey="pods"
         loading={!dataSource}

--- a/packages/refine/src/hooks/useEagleTable/columns.tsx
+++ b/packages/refine/src/hooks/useEagleTable/columns.tsx
@@ -1,5 +1,6 @@
 import { useUIKit } from '@cloudtower/eagle';
 import { useGo, useNavigation, useParsed } from '@refinedev/core';
+import { i18n as I18nType } from 'i18next';
 import type { OwnerReference } from 'kubernetes-types/meta/v1';
 import type { IngressBackend } from 'kubernetes-types/networking/v1';
 import { get } from 'lodash';
@@ -11,7 +12,6 @@ import { ReferenceLink } from '../../components/ReferenceLink';
 import { StateTag } from '../../components/StateTag';
 import { Column } from '../../components/Table';
 import Time from '../../components/Time';
-import i18n from '../../i18n';
 import {
   JobModel,
   PodModel,
@@ -59,6 +59,7 @@ export const CommonSorter = (dataIndex: string[]) => (a: unknown, b: unknown) =>
 };
 
 export const NameColumnRenderer = <Model extends ResourceModel>(
+  i18n: I18nType,
   resource = ''
 ): Column<Model> => {
   const dataIndex = ['metadata', 'name'];
@@ -75,7 +76,9 @@ export const NameColumnRenderer = <Model extends ResourceModel>(
   };
 };
 
-export const NameSpaceColumnRenderer = <Model extends ResourceModel>(): Column<Model> => {
+export const NameSpaceColumnRenderer = <Model extends ResourceModel>(
+  i18n: I18nType
+): Column<Model> => {
   const dataIndex = ['metadata', 'namespace'];
   return {
     key: 'namespace',
@@ -89,7 +92,9 @@ export const NameSpaceColumnRenderer = <Model extends ResourceModel>(): Column<M
 
 export const StateDisplayColumnRenderer = <
   Model extends WorkloadModel | CronJobModel | PodModel,
->(): Column<Model> => {
+>(
+  i18n: I18nType
+): Column<Model> => {
   const dataIndex = ['stateDisplay'];
   return {
     key: 'stateDisplay',
@@ -102,9 +107,9 @@ export const StateDisplayColumnRenderer = <
   };
 };
 
-export const WorkloadImageColumnRenderer = <
-  Model extends WorkloadBaseModel,
->(): Column<Model> => {
+export const WorkloadImageColumnRenderer = <Model extends WorkloadBaseModel>(
+  i18n: I18nType
+): Column<Model> => {
   const dataIndex = ['imageNames'];
   return {
     key: 'image',
@@ -119,9 +124,9 @@ export const WorkloadImageColumnRenderer = <
   };
 };
 
-export const WorkloadRestartsColumnRenderer = <
-  Model extends WorkloadModel,
->(): Column<Model> => {
+export const WorkloadRestartsColumnRenderer = <Model extends WorkloadModel>(
+  i18n: I18nType
+): Column<Model> => {
   const dataIndex = ['restarts'];
   return {
     key: 'restarts',
@@ -132,7 +137,9 @@ export const WorkloadRestartsColumnRenderer = <
   };
 };
 
-export const ReplicasColumnRenderer = <Model extends WorkloadModel>(): Column<Model> => {
+export const ReplicasColumnRenderer = <Model extends WorkloadModel>(
+  i18n: I18nType
+): Column<Model> => {
   const dataIndex = ['status', 'replicas'];
   return {
     key: 'replicas',
@@ -151,7 +158,9 @@ export const ReplicasColumnRenderer = <Model extends WorkloadModel>(): Column<Mo
   };
 };
 
-export const AgeColumnRenderer = <Model extends ResourceModel>(): Column<Model> => {
+export const AgeColumnRenderer = <Model extends ResourceModel>(
+  i18n: I18nType
+): Column<Model> => {
   const dataIndex = ['metadata', 'creationTimestamp'];
   return {
     key: 'creationTimestamp',
@@ -173,6 +182,7 @@ export const AgeColumnRenderer = <Model extends ResourceModel>(): Column<Model> 
 };
 
 export const NodeNameColumnRenderer = <Model extends PodModel>(
+  i18n: I18nType,
   options?: Partial<Column<Model>>
 ): Column<Model> => {
   const dataIndex = ['spec', 'nodeName'];
@@ -188,7 +198,9 @@ export const NodeNameColumnRenderer = <Model extends PodModel>(
   };
 };
 
-export const RestartCountColumnRenderer = <Model extends PodModel>(): Column<Model> => {
+export const RestartCountColumnRenderer = <Model extends PodModel>(
+  i18n: I18nType
+): Column<Model> => {
   const dataIndex = ['restartCount'];
   return {
     key: 'restartCount',
@@ -200,9 +212,9 @@ export const RestartCountColumnRenderer = <Model extends PodModel>(): Column<Mod
   };
 };
 
-export const CompletionsCountColumnRenderer = <
-  Model extends JobModel | CronJobModel,
->(): Column<Model> => {
+export const CompletionsCountColumnRenderer = <Model extends JobModel | CronJobModel>(
+  i18n: I18nType
+): Column<Model> => {
   const dataIndex = ['completionsDisplay'];
   return {
     key: 'completions',
@@ -214,9 +226,9 @@ export const CompletionsCountColumnRenderer = <
   };
 };
 
-export const DurationColumnRenderer = <
-  Model extends JobModel | CronJobModel,
->(): Column<Model> => {
+export const DurationColumnRenderer = <Model extends JobModel | CronJobModel>(
+  i18n: I18nType
+): Column<Model> => {
   const dataIndex = ['duration'];
   return {
     key: 'duration',
@@ -237,9 +249,9 @@ export const DurationColumnRenderer = <
   };
 };
 
-export const ServiceTypeColumnRenderer = <
-  Model extends ResourceModel,
->(): Column<Model> => {
+export const ServiceTypeColumnRenderer = <Model extends ResourceModel>(
+  i18n: I18nType
+): Column<Model> => {
   const dataIndex = ['spec', 'type'];
   return {
     key: 'type',
@@ -250,7 +262,9 @@ export const ServiceTypeColumnRenderer = <
     sorter: CommonSorter(dataIndex),
   };
 };
-export const PodWorkloadColumnRenderer = <Model extends PodModel>(): Column<Model> => {
+export const PodWorkloadColumnRenderer = <Model extends PodModel>(
+  i18n: I18nType
+): Column<Model> => {
   const dataIndex = ['metadata', 'ownerReferences'];
   return {
     key: 'type',
@@ -271,9 +285,9 @@ export const PodWorkloadColumnRenderer = <Model extends PodModel>(): Column<Mode
   };
 };
 
-export const IngressRulesColumnRenderer = <
-  Model extends IngressModel,
->(): Column<Model> => {
+export const IngressRulesColumnRenderer = <Model extends IngressModel>(
+  i18n: I18nType
+): Column<Model> => {
   const dataIndex = ['spec', 'rules'];
   return {
     key: 'type',
@@ -288,9 +302,9 @@ export const IngressRulesColumnRenderer = <
   };
 };
 
-export const IngressDefaultBackendColumnRenderer = <
-  Model extends IngressModel,
->(): Column<Model> => {
+export const IngressDefaultBackendColumnRenderer = <Model extends IngressModel>(
+  i18n: I18nType
+): Column<Model> => {
   const dataIndex = ['spec', 'defaultBackend'];
   return {
     key: 'defaultBackend',

--- a/packages/refine/src/index.ts
+++ b/packages/refine/src/index.ts
@@ -1,3 +1,6 @@
+import i18n from './i18n';
+export const dovetailRefineI18n = i18n;
+
 export * from './providers';
 export * from './hooks';
 export * from './components';

--- a/packages/refine/src/locales/en-US/dovetail.json
+++ b/packages/refine/src/locales/en-US/dovetail.json
@@ -13,5 +13,6 @@
   "obtain_data_error": "Having trouble getting data.",
   "retry": "Retry",
   "create_resource": "Create {{resource}}",
-  "edit_resource": "Edit {{resource}}"
+  "edit_resource": "Edit {{resource}}",
+  "status": "Status"
 }

--- a/packages/refine/src/pages/configmaps/index.ts
+++ b/packages/refine/src/pages/configmaps/index.ts
@@ -1,17 +1,18 @@
+import { i18n } from 'i18next';
 import { DataField } from '../../components/ShowContent';
 import { AgeColumnRenderer } from '../../hooks/useEagleTable/columns';
 import { ResourceModel } from '../../models';
 import { RESOURCE_GROUP, ResourceConfig } from '../../types';
 
-export const ConfigMapConfig: ResourceConfig<ResourceModel> = {
+export const ConfigMapConfig = (i18n: i18n): ResourceConfig<ResourceModel> => ({
   name: 'configmaps',
   kind: 'ConfigMap',
   basePath: '/api/v1',
   apiVersion: 'v1',
   parent: RESOURCE_GROUP.STORAGE,
   label: 'ConfigMaps',
-  columns: () => [AgeColumnRenderer()],
+  columns: () => [AgeColumnRenderer(i18n)],
   showConfig: () => ({
-    tabs: [DataField()],
+    tabs: [DataField(i18n)],
   }),
-};
+});

--- a/packages/refine/src/pages/cronjobs/list/index.tsx
+++ b/packages/refine/src/pages/cronjobs/list/index.tsx
@@ -1,5 +1,6 @@
 import { IResourceComponentsProps } from '@refinedev/core';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { CronJobDropdown } from 'src/components/CronJobDropdown';
 import { ListPage } from 'src/components/ListPage';
 import Time from 'src/components/Time';
@@ -11,17 +12,17 @@ import {
   NameSpaceColumnRenderer,
   StateDisplayColumnRenderer,
 } from 'src/hooks/useEagleTable/columns';
-import i18n from '../../../i18n';
 import { CronJobModel } from '../../../models';
 
 export const CronJobList: React.FC<IResourceComponentsProps> = () => {
+  const { i18n } = useTranslation();
   const { tableProps, selectedKeys } = useEagleTable<CronJobModel>({
     useTableParams: {},
     columns: [
-      StateDisplayColumnRenderer(),
-      NameColumnRenderer(),
-      NameSpaceColumnRenderer(),
-      WorkloadImageColumnRenderer(),
+      StateDisplayColumnRenderer(i18n),
+      NameColumnRenderer(i18n),
+      NameSpaceColumnRenderer(i18n),
+      WorkloadImageColumnRenderer(i18n),
       {
         key: 'schedule',
         display: true,
@@ -39,7 +40,7 @@ export const CronJobList: React.FC<IResourceComponentsProps> = () => {
           return <Time date={value} />;
         },
       },
-      AgeColumnRenderer(),
+      AgeColumnRenderer(i18n),
     ],
     tableProps: {
       currentSize: 10,

--- a/packages/refine/src/pages/cronjobs/show/index.tsx
+++ b/packages/refine/src/pages/cronjobs/show/index.tsx
@@ -1,17 +1,21 @@
 import { IResourceComponentsProps } from '@refinedev/core';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { CronJobDropdown } from '../../../components/CronJobDropdown';
 import { PageShow } from '../../../components/PageShow';
 import { ImageField, JobsField } from '../../../components/ShowContent/fields';
 import { CronJobModel } from '../../../models';
 
 export const CronJobShow: React.FC<IResourceComponentsProps> = () => {
+  const { i18n } = useTranslation();
   return (
     <PageShow<CronJobModel>
       showConfig={{
-        groups: [{
-          fields: [ImageField()]
-        }],
+        groups: [
+          {
+            fields: [ImageField(i18n)],
+          },
+        ],
         tabs: [JobsField()],
       }}
       Dropdown={CronJobDropdown}

--- a/packages/refine/src/pages/daemonsets/list/index.tsx
+++ b/packages/refine/src/pages/daemonsets/list/index.tsx
@@ -1,5 +1,6 @@
 import { IResourceComponentsProps } from '@refinedev/core';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { ListPage } from 'src/components/ListPage';
 import { WorkloadDropdown } from 'src/components/WorkloadDropdown';
 import { useEagleTable } from 'src/hooks/useEagleTable';
@@ -14,13 +15,14 @@ import {
 import { WorkloadModel } from '../../../models';
 
 export const DaemonSetList: React.FC<IResourceComponentsProps> = () => {
+  const { i18n } = useTranslation();
   const { tableProps, selectedKeys } = useEagleTable<WorkloadModel>({
     useTableParams: {},
     columns: [
-      StateDisplayColumnRenderer(),
-      NameColumnRenderer(),
-      NameSpaceColumnRenderer(),
-      WorkloadImageColumnRenderer(),
+      StateDisplayColumnRenderer(i18n),
+      NameColumnRenderer(i18n),
+      NameSpaceColumnRenderer(i18n),
+      WorkloadImageColumnRenderer(i18n),
       {
         key: 'ready',
         display: true,
@@ -28,8 +30,8 @@ export const DaemonSetList: React.FC<IResourceComponentsProps> = () => {
         title: 'Ready',
         sortable: true,
       },
-      WorkloadRestartsColumnRenderer(),
-      AgeColumnRenderer(),
+      WorkloadRestartsColumnRenderer(i18n),
+      AgeColumnRenderer(i18n),
     ],
     tableProps: {
       currentSize: 10,

--- a/packages/refine/src/pages/daemonsets/show/index.tsx
+++ b/packages/refine/src/pages/daemonsets/show/index.tsx
@@ -8,15 +8,19 @@ import {
   PodsField,
 } from '../../../components/ShowContent/fields';
 import { WorkloadModel } from '../../../models';
+import { useTranslation } from 'react-i18next';
 
 export const DaemonSetShow: React.FC<IResourceComponentsProps> = () => {
+  const { i18n } = useTranslation();
   return (
     <PageShow<WorkloadModel>
       showConfig={{
-        groups: [{
-          fields: [ImageField()]
-        }],
-        tabs: [PodsField(), ConditionsField()],
+        groups: [
+          {
+            fields: [ImageField(i18n)],
+          },
+        ],
+        tabs: [PodsField(), ConditionsField(i18n)],
       }}
       Dropdown={WorkloadDropdown}
     />

--- a/packages/refine/src/pages/deployments/list/index.tsx
+++ b/packages/refine/src/pages/deployments/list/index.tsx
@@ -1,5 +1,6 @@
 import { IResourceComponentsProps } from '@refinedev/core';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { ListPage } from 'src/components/ListPage';
 import { WorkloadDropdown } from 'src/components/WorkloadDropdown';
 import { useEagleTable } from 'src/hooks/useEagleTable';
@@ -15,16 +16,17 @@ import {
 import { WorkloadModel } from '../../../models';
 
 export const DeploymentList: React.FC<IResourceComponentsProps> = () => {
+  const { i18n } = useTranslation();
   const { tableProps, selectedKeys } = useEagleTable<WorkloadModel>({
     useTableParams: {},
     columns: [
-      StateDisplayColumnRenderer(),
-      NameColumnRenderer(),
-      NameSpaceColumnRenderer(),
-      WorkloadImageColumnRenderer(),
-      WorkloadRestartsColumnRenderer(),
-      ReplicasColumnRenderer(),
-      AgeColumnRenderer(),
+      StateDisplayColumnRenderer(i18n),
+      NameColumnRenderer(i18n),
+      NameSpaceColumnRenderer(i18n),
+      WorkloadImageColumnRenderer(i18n),
+      WorkloadRestartsColumnRenderer(i18n),
+      ReplicasColumnRenderer(i18n),
+      AgeColumnRenderer(i18n),
     ],
     tableProps: {
       currentSize: 10,

--- a/packages/refine/src/pages/deployments/show/index.tsx
+++ b/packages/refine/src/pages/deployments/show/index.tsx
@@ -1,5 +1,6 @@
 import { IResourceComponentsProps } from '@refinedev/core';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { PageShow } from '../../../components/PageShow';
 import {
   ConditionsField,
@@ -12,13 +13,16 @@ import { WorkloadDropdown } from '../../../components/WorkloadDropdown';
 import { WorkloadModel } from '../../../models';
 
 export const DeploymentShow: React.FC<IResourceComponentsProps> = () => {
+  const { i18n } = useTranslation();
   return (
     <PageShow<WorkloadModel>
       showConfig={{
-        groups: [{
-          fields: [ImageField(), ReplicaField()]
-        }],
-        tabs: [PodsField(), ConditionsField(), EventsTableTabField()],
+        groups: [
+          {
+            fields: [ImageField(i18n), ReplicaField(i18n)],
+          },
+        ],
+        tabs: [PodsField(), ConditionsField(i18n), EventsTableTabField(i18n)],
       }}
       Dropdown={WorkloadDropdown}
     />

--- a/packages/refine/src/pages/ingresses/index.tsx
+++ b/packages/refine/src/pages/ingresses/index.tsx
@@ -1,3 +1,4 @@
+import { i18n } from 'i18next';
 import { Column, IngressRulesTableTabField } from '../../components';
 import K8sDropdown from '../../components/K8sDropdown';
 import { INGRESS_INIT_VALUE } from '../../constants/k8s';
@@ -9,7 +10,7 @@ import {
 import { IngressModel } from '../../models';
 import { RESOURCE_GROUP, ResourceConfig, FormType } from '../../types';
 
-export const IngressConfig: ResourceConfig<IngressModel> = {
+export const IngressConfig = (i18n: i18n): ResourceConfig<IngressModel> => ({
   name: 'ingresses',
   kind: 'Ingress',
   basePath: '/apis/networking.k8s.io/v1',
@@ -18,16 +19,16 @@ export const IngressConfig: ResourceConfig<IngressModel> = {
   parent: RESOURCE_GROUP.NETWORK,
   columns: () =>
     [
-      IngressDefaultBackendColumnRenderer(),
-      IngressRulesColumnRenderer(),
-      AgeColumnRenderer(),
+      IngressDefaultBackendColumnRenderer(i18n),
+      IngressRulesColumnRenderer(i18n),
+      AgeColumnRenderer(i18n),
     ] as Column<IngressModel>[],
   showConfig: () => ({
     descriptions: [],
     groups: [],
-    tabs: [IngressRulesTableTabField()],
+    tabs: [IngressRulesTableTabField(i18n)],
   }),
   initValue: INGRESS_INIT_VALUE,
   Dropdown: K8sDropdown,
   formType: FormType.MODAL,
-};
+});

--- a/packages/refine/src/pages/jobs/index.ts
+++ b/packages/refine/src/pages/jobs/index.ts
@@ -1,3 +1,4 @@
+import { i18n } from 'i18next';
 import { FormType } from 'src/types';
 import { Column } from '../../components';
 import K8sDropdown from '../../components/K8sDropdown';
@@ -19,7 +20,7 @@ import {
 import { JobModel } from '../../models';
 import { RESOURCE_GROUP, ResourceConfig } from '../../types';
 
-export const JobConfig: ResourceConfig<JobModel> = {
+export const JobConfig = (i18n: i18n): ResourceConfig<JobModel> => ({
   name: 'jobs',
   kind: 'Job',
   basePath: '/apis/batch/v1',
@@ -28,21 +29,23 @@ export const JobConfig: ResourceConfig<JobModel> = {
   parent: RESOURCE_GROUP.WORKLOAD,
   columns: () =>
     [
-      StateDisplayColumnRenderer(),
-      WorkloadImageColumnRenderer(),
-      CompletionsCountColumnRenderer(),
-      WorkloadRestartsColumnRenderer(),
-      DurationColumnRenderer(),
-      AgeColumnRenderer(),
+      StateDisplayColumnRenderer(i18n),
+      WorkloadImageColumnRenderer(i18n),
+      CompletionsCountColumnRenderer(i18n),
+      WorkloadRestartsColumnRenderer(i18n),
+      DurationColumnRenderer(i18n),
+      AgeColumnRenderer(i18n),
     ] as Column<JobModel>[],
   showConfig: () => ({
     descriptions: [],
-    groups: [{
-      fields: [StartTimeField(), ImageField()],
-    }],
-    tabs: [PodsField(), ConditionsField()]
+    groups: [
+      {
+        fields: [StartTimeField(i18n), ImageField(i18n)],
+      },
+    ],
+    tabs: [PodsField(), ConditionsField(i18n)],
   }),
   initValue: JOB_INIT_VALUE,
   Dropdown: K8sDropdown,
-  formType: FormType.MODAL
-};
+  formType: FormType.MODAL,
+});

--- a/packages/refine/src/pages/networkPolicies/index.tsx
+++ b/packages/refine/src/pages/networkPolicies/index.tsx
@@ -1,3 +1,4 @@
+import { i18n } from 'i18next';
 import type { LabelSelector } from 'kubernetes-types/meta/v1';
 import type {
   NetworkPolicyIngressRule,
@@ -12,7 +13,7 @@ import { AgeColumnRenderer } from '../../hooks/useEagleTable/columns';
 import { NetworkPolicyModel } from '../../models';
 import { RESOURCE_GROUP, ResourceConfig, FormType } from '../../types';
 
-export const NetworkPolicyConfig: ResourceConfig<NetworkPolicyModel> = {
+export const NetworkPolicyConfig = (i18n: i18n): ResourceConfig<NetworkPolicyModel> => ({
   name: 'networkpolicies',
   kind: 'NetworkPolicy',
   basePath: '/apis/networking.k8s.io/v1',
@@ -31,7 +32,7 @@ export const NetworkPolicyConfig: ResourceConfig<NetworkPolicyModel> = {
           return <Tags value={matchLabels} />;
         },
       },
-      AgeColumnRenderer(),
+      AgeColumnRenderer(i18n),
     ] as Column<NetworkPolicyModel>[],
   showConfig: () => ({
     descriptions: [],
@@ -80,4 +81,4 @@ export const NetworkPolicyConfig: ResourceConfig<NetworkPolicyModel> = {
   initValue: NETWORK_POLICY_INIT_VALUE,
   Dropdown: K8sDropdown,
   formType: FormType.MODAL,
-};
+});

--- a/packages/refine/src/pages/pods/list/index.tsx
+++ b/packages/refine/src/pages/pods/list/index.tsx
@@ -1,6 +1,7 @@
 import { IResourceComponentsProps, useList } from '@refinedev/core';
 import { compact } from 'lodash-es';
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Column } from '../../../components';
 import { ListPage } from '../../../components/ListPage';
 import { useEagleTable } from '../../../hooks/useEagleTable';
@@ -18,6 +19,7 @@ import {
 import { PodMetricsModel, PodModel } from '../../../models';
 
 export const PodList: React.FC<IResourceComponentsProps> = () => {
+  const { i18n } = useTranslation();
   const { data: metricsData } = useList<PodMetricsModel>({
     resource: 'podMetrics',
     meta: {
@@ -41,10 +43,10 @@ export const PodList: React.FC<IResourceComponentsProps> = () => {
   const { tableProps, selectedKeys } = useEagleTable<PodModel>({
     useTableParams: {},
     columns: compact([
-      StateDisplayColumnRenderer(),
-      NameColumnRenderer(),
-      NameSpaceColumnRenderer(),
-      WorkloadImageColumnRenderer(),
+      StateDisplayColumnRenderer(i18n),
+      NameColumnRenderer(i18n),
+      NameSpaceColumnRenderer(i18n),
+      WorkloadImageColumnRenderer(i18n),
       {
         key: 'readyDisplay',
         display: true,
@@ -53,9 +55,9 @@ export const PodList: React.FC<IResourceComponentsProps> = () => {
         sortable: true,
         sorter: CommonSorter(['readyDisplay']),
       },
-      RestartCountColumnRenderer(),
-      NodeNameColumnRenderer(),
-      PodWorkloadColumnRenderer(),
+      RestartCountColumnRenderer(i18n),
+      NodeNameColumnRenderer(i18n),
+      PodWorkloadColumnRenderer(i18n),
       supportMetrics && {
         key: 'memory_usage',
         display: true,
@@ -86,7 +88,7 @@ export const PodList: React.FC<IResourceComponentsProps> = () => {
         sortable: true,
         sorter: CommonSorter(['status', 'podIP']),
       },
-      AgeColumnRenderer(),
+      AgeColumnRenderer(i18n),
     ]) as Column<PodModel>[],
     tableProps: {
       currentSize: 10,

--- a/packages/refine/src/pages/pods/show/index.tsx
+++ b/packages/refine/src/pages/pods/show/index.tsx
@@ -51,7 +51,7 @@ export const PodShow: React.FC<IResourceComponentsProps> = () => {
               );
             },
           },
-          ConditionsField(),
+          ConditionsField(i18n),
           {
             key: 'log',
             title: i18n.t('dovetail.log'),

--- a/packages/refine/src/pages/secrets/index.ts
+++ b/packages/refine/src/pages/secrets/index.ts
@@ -1,17 +1,18 @@
+import { i18n } from 'i18next';
 import { SecretDataField } from '../../components/ShowContent';
 import { AgeColumnRenderer } from '../../hooks/useEagleTable/columns';
 import { ResourceModel } from '../../models';
 import { RESOURCE_GROUP, ResourceConfig } from '../../types';
 
-export const SecretsConfig: ResourceConfig<ResourceModel> = {
+export const SecretsConfig = (i18n: i18n): ResourceConfig<ResourceModel> => ({
   name: 'secrets',
   kind: 'Secret',
   basePath: '/api/v1',
   apiVersion: 'v1',
   parent: RESOURCE_GROUP.STORAGE,
   label: 'Secrets',
-  columns: () => [AgeColumnRenderer()],
+  columns: () => [AgeColumnRenderer(i18n)],
   showConfig: () => ({
-    tabs: [SecretDataField()]
+    tabs: [SecretDataField(i18n)],
   }),
-};
+});

--- a/packages/refine/src/pages/services/index.ts
+++ b/packages/refine/src/pages/services/index.ts
@@ -1,3 +1,4 @@
+import { i18n } from 'i18next';
 import {
   ConditionsField,
   ServiceTypeField,
@@ -13,19 +14,25 @@ import {
 import { ResourceModel } from '../../models';
 import { RESOURCE_GROUP, ResourceConfig } from '../../types';
 
-export const ServicesConfig: ResourceConfig<ResourceModel> = {
+export const ServicesConfig = (i18n: i18n): ResourceConfig<ResourceModel> => ({
   name: 'services',
   kind: 'Service',
   basePath: '/api/v1',
   apiVersion: 'v1',
   label: 'Services',
   parent: RESOURCE_GROUP.NETWORK,
-  columns: () => [ServiceTypeColumnRenderer(), AgeColumnRenderer()],
+  columns: () => [ServiceTypeColumnRenderer(i18n), AgeColumnRenderer(i18n)],
   showConfig: () => ({
-    groups: [{
-      fields: [ServiceTypeField(), ClusterIpField(), SessionAffinityField()],
-    }],
-    tabs: [ServicePodsField(), ConditionsField()],
+    groups: [
+      {
+        fields: [
+          ServiceTypeField(i18n),
+          ClusterIpField(i18n),
+          SessionAffinityField(i18n),
+        ],
+      },
+    ],
+    tabs: [ServicePodsField(), ConditionsField(i18n)],
   }),
   initValue: SERVICE_INIT_VALUE,
-};
+});

--- a/packages/refine/src/pages/statefulsets/list/index.tsx
+++ b/packages/refine/src/pages/statefulsets/list/index.tsx
@@ -1,5 +1,6 @@
 import { IResourceComponentsProps } from '@refinedev/core';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { ListPage } from 'src/components/ListPage';
 import { WorkloadDropdown } from 'src/components/WorkloadDropdown';
 import { useEagleTable } from 'src/hooks/useEagleTable';
@@ -15,16 +16,17 @@ import {
 import { WorkloadModel } from '../../../models';
 
 export const StatefulSetList: React.FC<IResourceComponentsProps> = () => {
+  const { i18n } = useTranslation();
   const { tableProps, selectedKeys } = useEagleTable<WorkloadModel>({
     useTableParams: {},
     columns: [
-      StateDisplayColumnRenderer(),
-      NameColumnRenderer(),
-      NameSpaceColumnRenderer(),
-      WorkloadImageColumnRenderer(),
-      WorkloadRestartsColumnRenderer(),
-      ReplicasColumnRenderer(),
-      AgeColumnRenderer(),
+      StateDisplayColumnRenderer(i18n),
+      NameColumnRenderer(i18n),
+      NameSpaceColumnRenderer(i18n),
+      WorkloadImageColumnRenderer(i18n),
+      WorkloadRestartsColumnRenderer(i18n),
+      ReplicasColumnRenderer(i18n),
+      AgeColumnRenderer(i18n),
     ],
     tableProps: {
       currentSize: 10,

--- a/packages/refine/src/pages/statefulsets/show/index.tsx
+++ b/packages/refine/src/pages/statefulsets/show/index.tsx
@@ -1,5 +1,6 @@
 import { IResourceComponentsProps } from '@refinedev/core';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { WorkloadDropdown } from 'src/components/WorkloadDropdown';
 import { PageShow } from '../../../components/PageShow';
 import {
@@ -11,13 +12,17 @@ import {
 import { WorkloadModel } from '../../../models';
 
 export const StatefulSetShow: React.FC<IResourceComponentsProps> = () => {
+  const { i18n } = useTranslation();
+
   return (
     <PageShow<WorkloadModel>
       showConfig={{
-        groups: [{
-          fields: [ImageField(), ReplicaField()]
-        }],
-        tabs: [PodsField(), ConditionsField()]
+        groups: [
+          {
+            fields: [ImageField(i18n), ReplicaField(i18n)],
+          },
+        ],
+        tabs: [PodsField(), ConditionsField(i18n)],
       }}
       Dropdown={WorkloadDropdown}
     />


### PR DESCRIPTION
# 背景
主要目的是能够让ColumnRenderer和ShowFiled中的title的i18n能够响应语言切换的变化。

# 改动
1. d2 暴露自己的 i18n 实例出来
2. ColumnRenderer和ShowFiled的函数都接受一个 i18n 实例为参数，因为这两个东西不是组件，不能用 hook。这个 i18n 实例应该是 d2 i18n实例，有d2的词条，而不是应用的 i18n。
3. 给Dovetail组件加了一个I18nextProvider，让 d2 内部的 useTranslation 拿到的都是 d2 的 i18n。