### PR TITLE
fix: fix the yaml didn't fold after opening modal again and disable the telemetry

### DIFF
--- a/packages/refine/src/Dovetail.tsx
+++ b/packages/refine/src/Dovetail.tsx
@@ -57,6 +57,7 @@ export const Dovetail: React.FC<Props> = props => {
               options={{
                 warnWhenUnsavedChanges: true,
                 liveMode: 'auto',
+                disableTelemetry: true,
               }}
               resources={resourcesConfig.map(c => {
                 return {

--- a/packages/refine/src/hooks/useEagleForm.ts
+++ b/packages/refine/src/hooks/useEagleForm.ts
@@ -142,7 +142,6 @@ const useEagleForm = <
   TResponseError
 > => {
   const editor = useRef<YamlEditorHandle>(null);
-  const isFoldRef = useRef<boolean>(false);
   const { t } = useTranslation();
   const [enableEditor, setEnableEditor] = useState(false);
   const [isYamlValid, setIsYamlValid] = useState(true);
@@ -231,9 +230,8 @@ const useEagleForm = <
 
       editor.current.setEditorValue(editorValue);
       editor.current.setValue(editorValue);
-      if (queryResult?.data?.data && editorInstance && !isFoldRef.current) {
+      if (queryResult?.data?.data && editorInstance) {
         fold(editorInstance);
-        isFoldRef.current = true;
       }
     }
   }, [initialValues, queryResult?.data?.data, id, form, fold]);
@@ -285,13 +283,7 @@ const useEagleForm = <
         setEditorErrors([]);
       }
     },
-    onEditorCreate(editor) {
-      if (queryResult?.data?.data && !isFoldRef.current) {
-        fold(editor);
-        isFoldRef.current = true;
-      }
-    },
-  }), [editorErrors, editorOptions, fold, initialValues, queryResult?.data?.data, schema, useResourceResult.resource?.name]);
+  }), [editorErrors, editorOptions, initialValues, schema, useResourceResult.resource?.name]);
 
   return {
     form: formSF.form,


### PR DESCRIPTION
1. 禁止 refine 发送收集信息的请求，https://refine.dev/docs/core/refine-component/#disabletelemetry
2. 修复再次打开模态框时 YAML 没有折叠的问题