### PR TITLE
fix: changes when the editor sets the initial value

### DIFF
--- a/packages/refine/src/components/FormModal/index.tsx
+++ b/packages/refine/src/components/FormModal/index.tsx
@@ -47,6 +47,7 @@ export function FormModal(props: FormModalProps) {
     ...props.formProps,
     initialValues: props.formProps?.initialValues || config?.initValue,
     id,
+    action: id ? 'edit' : 'create',
     isShowLayout: false,
     useFormProps: {
       redirect: false,


### PR DESCRIPTION
修复编辑器偶尔出现编辑过程中数据更新的问题。

之前通过设置 `liveMode: 'off'` 来关闭数据更新似乎不能完全组件数据更新，现在移除 `useEffect` 中更新编辑器值的逻辑，只在编辑器创建的时候初始化一次，并添加 loading 之后再渲染编辑器的逻辑，以保证编辑器创建的时候已经完成数据获取。