### PR TITLE
only use unit up to day when displaying age

### DIFF
--- a/packages/refine/src/components/Time/index.tsx
+++ b/packages/refine/src/components/Time/index.tsx
@@ -5,7 +5,17 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-dayjs.extend(relativeTime);
+dayjs.extend(relativeTime, {
+  thresholds: [
+    { l: 's', r: 1 },
+    { l: 'm', r: 1 },
+    { l: 'mm', r: 59, d: 'minute' },
+    { l: 'h', r: 1 },
+    { l: 'hh', r: 23, d: 'hour' },
+    { l: 'd', r: 1 },
+    { l: 'dd', r: Infinity, d: 'day' },
+  ],
+});
 
 const Time: React.FunctionComponent<{
   className?: string;


### PR DESCRIPTION
显示时间单位的时候，最多显示到天，不用月和年
![截屏2024-03-04 11 49 40](https://github.com/webzard-io/dovetail-v2/assets/12260952/22e2dc99-3c05-49b5-aa4c-ee9972b0e47c)
