### PR TITLE
use cluster vip in nodePort Service

### DIFF
--- a/packages/refine/src/components/ServiceComponents/index.tsx
+++ b/packages/refine/src/components/ServiceComponents/index.tsx
@@ -1,5 +1,5 @@
+import { Link } from '@cloudtower/eagle';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { ServiceModel, ServiceTypeEnum } from '../../models';
 
 type Props = {
@@ -16,8 +16,9 @@ export const ServiceInClusterAccessComponent: React.FC<Props> = ({ service }) =>
   }
 };
 
-export const ServiceOutClusterAccessComponent: React.FC<Props> = ({ service }) => {
-  const i18n = useTranslation();
+export const ServiceOutClusterAccessComponent: React.FC<
+  Props & { clusterVip: string }
+> = ({ service, clusterVip }) => {
   const spec = service._rawYaml.spec;
   switch (spec.type) {
     case ServiceTypeEnum.NodePort:
@@ -25,7 +26,9 @@ export const ServiceOutClusterAccessComponent: React.FC<Props> = ({ service }) =
         ?.filter(v => !!v)
         .map(p => (
           <li key={p.nodePort}>
-            {i18n.t('dovetail.any_node_ip')}: {p.nodePort}
+            <Link target="_blank" href={`http://${clusterVip}:${p.nodePort}`}>
+              {clusterVip}:{p.nodePort}
+            </Link>
           </li>
         ));
       return <ul>{content}</ul>;

--- a/packages/refine/src/hooks/index.ts
+++ b/packages/refine/src/hooks/index.ts
@@ -5,3 +5,4 @@ export * from './useEagleTable';
 export * from './useDownloadYAML';
 export * from './useEdit';
 export * from './useGlobalStore';
+export * from './useOpenForm';

--- a/packages/refine/src/hooks/useEagleTable/columns.tsx
+++ b/packages/refine/src/hooks/useEagleTable/columns.tsx
@@ -102,7 +102,13 @@ export const NameSpaceColumnRenderer = <Model extends ResourceModel>(
 };
 
 export const StateDisplayColumnRenderer = <
-  Model extends WorkloadModel | CronJobModel | PodModel | ServiceModel | DaemonSetModel | JobModel,
+  Model extends
+    | WorkloadModel
+    | CronJobModel
+    | PodModel
+    | ServiceModel
+    | DaemonSetModel
+    | JobModel,
 >(
   i18n: I18nType
 ): Column<Model> => {
@@ -301,7 +307,8 @@ export const ServiceInClusterAccessColumnRenderer = <Model extends ServiceModel>
 };
 
 export const ServiceOutClusterAccessColumnRenderer = <Model extends ServiceModel>(
-  i18n: I18nType
+  i18n: I18nType,
+  clusterVip: string
 ): Column<Model> => {
   return {
     key: 'outClusterAccess',
@@ -310,11 +317,7 @@ export const ServiceOutClusterAccessColumnRenderer = <Model extends ServiceModel
     dataIndex: [],
     render(_, record) {
       return (
-        <ServiceOutClusterAccessComponent
-          service={record}
-          // the API_HOST in vite.config.js
-          clusterVip="192.168.31.86"
-        />
+        <ServiceOutClusterAccessComponent service={record} clusterVip={clusterVip} />
       );
     },
   };

--- a/packages/refine/src/hooks/useEagleTable/columns.tsx
+++ b/packages/refine/src/hooks/useEagleTable/columns.tsx
@@ -309,7 +309,13 @@ export const ServiceOutClusterAccessColumnRenderer = <Model extends ServiceModel
     display: true,
     dataIndex: [],
     render(_, record) {
-      return <ServiceOutClusterAccessComponent service={record} />;
+      return (
+        <ServiceOutClusterAccessComponent
+          service={record}
+          // the API_HOST in vite.config.js
+          clusterVip="192.168.31.86"
+        />
+      );
     },
   };
 };
@@ -430,4 +436,3 @@ export const PodContainersNumColumnRenderer = <Model extends PodModel>(
     sorter: CommonSorter(['readyDisplay']),
   };
 };
-

--- a/packages/refine/src/locales/en-US/dovetail.json
+++ b/packages/refine/src/locales/en-US/dovetail.json
@@ -91,7 +91,6 @@
   "port_mapping": "端口映射",
   "out_cluster_access": "集群外访问方式",
   "in_cluster_access": "集群内访问方式",
-  "any_node_ip": "任意节点 IP",
   "fail_get_detail": "{{resource}} {{name}} 已不存在",
   "basic_info": "Basic Information",
   "pod_selector": "Pod Selector",

--- a/packages/refine/src/locales/zh-CN/dovetail.json
+++ b/packages/refine/src/locales/zh-CN/dovetail.json
@@ -90,7 +90,6 @@
   "port_mapping": "端口映射",
   "out_cluster_access": "集群外访问方式",
   "in_cluster_access": "集群内访问方式",
-  "any_node_ip": "任意节点 IP",
   "fail_get_detail": "{{resource}} {{name}} 已不存在",
   "basic_info": "基本信息",
   "pod": "Pod",

--- a/packages/refine/src/pages/services/index.tsx
+++ b/packages/refine/src/pages/services/index.tsx
@@ -29,7 +29,7 @@ export const ServicesConfig = (i18n: i18n): ResourceConfig<ServiceModel> => ({
   columns: () => [
     ServiceTypeColumnRenderer(i18n),
     ServiceInClusterAccessColumnRenderer(i18n),
-    ServiceOutClusterAccessColumnRenderer(i18n),
+    ServiceOutClusterAccessColumnRenderer(i18n, '192.168.31.98'),
     {
       key: 'dnsRecord',
       title: i18n.t('dovetail.dns_record'),


### PR DESCRIPTION
在nodeport类型的service的「集群外访问方式中」，用实际的集群vip，替代「任意 IP」，拼成可跳转的链接

![截屏2024-03-06 15 01 36](https://github.com/webzard-io/dovetail-v2/assets/12260952/40ae7f30-f956-4e57-9c27-8b069a6c768c)
