### PR TITLE
fix refine form bugs

### DIFF
--- a/packages/refine/src/components/Form/FormModal.tsx
+++ b/packages/refine/src/components/Form/FormModal.tsx
@@ -83,6 +83,7 @@ export function FormModal(props: FormModalProps) {
       onMutationSuccess: () => {
         popModal();
       },
+      redirect: false,
     },
   });
 

--- a/packages/refine/src/components/Form/useRefineForm.ts
+++ b/packages/refine/src/components/Form/useRefineForm.ts
@@ -24,7 +24,7 @@ export const useRefineForm = (props: {
           message: i18n.t(
             id ? 'dovetail.edit_resource_success' : 'dovetail.create_success_toast',
             {
-              resource: config.name,
+              kind: formValue.kind,
               name: formValue.metadata.name,
               interpolation: { escapeValue: false },
             }


### PR DESCRIPTION
1. 修复创建资源成功后的toast文案错误，正确传递 kind 参数
2. refineForm弹窗成功创建资源后，不需要跳转页面