### PR TITLE
use succeeded number to sort in  job pods column

### DIFF
--- a/packages/refine/src/components/CronjobJobsTable/index.tsx
+++ b/packages/refine/src/components/CronjobJobsTable/index.tsx
@@ -15,7 +15,7 @@ import {
   StateDisplayColumnRenderer,
   WorkloadImageColumnRenderer,
 } from '../../hooks/useEagleTable/columns';
-import { CronJobModel } from '../../models';
+import { JobModel } from '../../models';
 import BaseTable, { Column } from '../Table';
 import { TableToolBar } from '../Table/TableToolBar';
 
@@ -27,7 +27,7 @@ const WrapperStyle = css`
 `;
 
 function matchOwner(
-  job: CronJobModel,
+  job: JobModel,
   owner: OwnerReference & { namespace: string }
 ): boolean {
   let match = false;
@@ -57,12 +57,12 @@ export const CronjobJobsTable: React.FC<{
   const Table = component.Table || BaseTable;
   const currentSize = 10;
 
-  const { data, isLoading } = useList<CronJobModel>({
+  const { data, isLoading } = useList<JobModel>({
     resource: 'jobs',
     meta: { resourceBasePath: '/apis/batch/v1', kind: 'Job' },
     pagination: {
-      mode: 'off'
-    }
+      mode: 'off',
+    },
   });
 
   const dataSource = useMemo(() => {
@@ -71,7 +71,7 @@ export const CronjobJobsTable: React.FC<{
     });
   }, [data?.data, owner]);
 
-  const columns: Column<CronJobModel>[] = [
+  const columns: Column<JobModel>[] = [
     NameColumnRenderer(i18n, 'jobs'),
     StateDisplayColumnRenderer(i18n),
     NameSpaceColumnRenderer(i18n),

--- a/packages/refine/src/hooks/useEagleTable/columns.tsx
+++ b/packages/refine/src/hooks/useEagleTable/columns.tsx
@@ -279,10 +279,10 @@ export const RestartCountColumnRenderer = <Model extends PodModel>(
   };
 };
 
-export const CompletionsCountColumnRenderer = <Model extends JobModel | CronJobModel>(
+export const CompletionsCountColumnRenderer = <Model extends JobModel>(
   i18n: I18nType
 ): Column<Model> => {
-  const dataIndex = ['completionsDisplay'];
+  const dataIndex = ['succeeded'];
 
   return {
     key: 'completions',
@@ -297,6 +297,9 @@ export const CompletionsCountColumnRenderer = <Model extends JobModel | CronJobM
     width: 120,
     align: 'right',
     sorter: CommonSorter(dataIndex),
+    render: (_, record: Model) => {
+      return <span>{record.completionsDisplay}</span>;
+    },
   };
 };
 


### PR DESCRIPTION
job的pods数量是用字符串排序的，所以会有些问题。现在改成使用succeeded来排序。
顺便修改了一些错误的类型。CompletionsCountColumnRenderer不需要兼容 Cronjob

![截屏2024-04-09 17 29 18](https://github.com/webzard-io/dovetail-v2/assets/12260952/6fc7d265-be1d-48f3-b80f-870f353f0aaa)


