### PR TITLE
Fix/d2

### DIFF
--- a/packages/refine/src/components/Form/FormModal.tsx
+++ b/packages/refine/src/components/Form/FormModal.tsx
@@ -147,10 +147,11 @@ export function FormModal(props: FormModalProps) {
 
   const onCancel = useCallback(() => {
     popModal();
-  }, []);
+  }, [popModal]);
 
   const onOk = useCallback(
     e => {
+      setIsError(false);
       saveButtonProps.onClick?.(e);
     },
     [saveButtonProps]
@@ -188,10 +189,13 @@ export function FormModal(props: FormModalProps) {
           ''
         )
       }
-      okButtonProps={{ ...saveButtonProps, children: config.formConfig?.saveButtonText }}
+      okButtonProps={{
+        ...saveButtonProps,
+        children: config.formConfig?.saveButtonText,
+        onClick: onOk
+      }}
       closeIcon={<CloseCircleFilled />}
       okText={okText}
-      onOk={onOk}
       onCancel={onCancel}
       destroyOnClose
       fullscreen

--- a/packages/refine/src/components/Form/YamlForm.tsx
+++ b/packages/refine/src/components/Form/YamlForm.tsx
@@ -37,6 +37,7 @@ export interface YamlFormProps {
   onSaveButtonPropsChange?: (saveButtonProps: {
     disabled?: boolean;
     onClick: () => void;
+    loading?: boolean | { delay?: number | undefined; };
   }) => void;
   onErrorsChange?: (errors: string[]) => void;
   onFinish?: () => void;
@@ -97,6 +98,7 @@ export function YamlForm(props: YamlFormProps) {
   const { t, i18n } = useTranslation();
 
   const FormWrapper = isShowLayout ? FormLayout : React.Fragment;
+  const formWrapperProps = isShowLayout ? { saveButtonProps } : {};
   // use useMemo to keep {} the same
   const schema = useMemo(() => {
     return editorProps.schema || {};
@@ -109,13 +111,20 @@ export function YamlForm(props: YamlFormProps) {
 
   const onFinish = useCallback(
     async store => {
-      const result = await formProps.onFinish?.(store);
-
-      if (result) {
-        props.onFinish?.();
+      try {
+        const result = await formProps.onFinish?.(store);
+        if (result) {
+          props.onFinish?.();
+        }
+      } catch {
+      } finally {
+        onSaveButtonPropsChange?.({
+          ...saveButtonProps,
+          loading: false
+        });
       }
     },
-    [formProps, props]
+    [formProps, props, saveButtonProps, onSaveButtonPropsChange]
   );
 
   useEffect(() => {
@@ -126,7 +135,7 @@ export function YamlForm(props: YamlFormProps) {
   }, [responseErrors, onErrorsChange]);
 
   return (
-    <FormWrapper saveButtonProps={saveButtonProps}>
+    <FormWrapper {...formWrapperProps}>
       <kit.form
         {...formProps}
         initialValues={formProps.initialValues}

--- a/packages/refine/src/components/WorkloadPodsTable/WorkloadPodsTable.tsx
+++ b/packages/refine/src/components/WorkloadPodsTable/WorkloadPodsTable.tsx
@@ -65,7 +65,7 @@ export const WorkloadPodsTable: React.FC<WorkloadPodsTableProps> = ({
           field: '',
           value: '',
           fn(item: PodModel) {
-            return matchSelector(item, selector, item.metadata.namespace);
+            return matchSelector(item, selector, namespace);
           }
         }] as any
       }


### PR DESCRIPTION
1. 修复传给 matchSelector 的 namespace 不正确的问题
2. 修复编辑提交失败后按钮一直 loading 的问题。排查不出是由于什么原因在 saveButtonProps 变化时没有触发 useEffect 的执行，先暂时在 onFinish 之后将 loading 设为 false 来解决这个问题