### PR TITLE
Bowen/bugfix 0516

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/src/components/YamlEditor/YamlEditorComponent.tsx
+++ b/packages/refine/src/components/YamlEditor/YamlEditorComponent.tsx
@@ -256,10 +256,10 @@ export const YamlEditorComponent = forwardRef<YamlEditorHandle, YamlEditorProps>
               <XmarkFailedSeriousWarningFill16RedIcon className={ErrorIconStyle} />
               <div>
                 {errorMsgs.map((errorMsg, index) => (
-                  <div className={ErrorMsgStyle} key={errorMsg}>
+                  <pre className={ErrorMsgStyle} key={errorMsg}>
                     {errorMsgs.length > 1 ? `${index + 1}. ` : ''}
                     {errorMsg}
-                  </div>
+                  </pre>
                 ))}
               </div>
             </kit.space>

--- a/packages/refine/src/hooks/useEagleTable/columns.tsx
+++ b/packages/refine/src/hooks/useEagleTable/columns.tsx
@@ -567,7 +567,7 @@ export const DataKeysColumnRenderer = <Model extends ResourceModel>(
 
 export const PortMappingColumnRenderer = <Model extends ServiceModel>(
   i18n: I18nType,
-  clusterVip: string,
+  clusterVip: string
 ): Column<Model> => {
   return {
     key: 'displayPortMapping',
@@ -585,7 +585,13 @@ export const PortMappingColumnRenderer = <Model extends ServiceModel>(
           content={
             <span style={{ whiteSpace: 'pre' }}>
               {record.displayType === 'NodePort' ? (
-                <Link href={`//${clusterVip}:${v.nodePort}`} target="_blank">
+                <Link
+                  href={`//${clusterVip}:${v.nodePort}`}
+                  target="_blank"
+                  className={css`
+                    padding: 0 !important;
+                  `}
+                >
                   {v.servicePort}
                 </Link>
               ) : (

--- a/packages/refine/src/hooks/useEagleTable/columns.tsx
+++ b/packages/refine/src/hooks/useEagleTable/columns.tsx
@@ -566,7 +566,8 @@ export const DataKeysColumnRenderer = <Model extends ResourceModel>(
 };
 
 export const PortMappingColumnRenderer = <Model extends ServiceModel>(
-  i18n: I18nType
+  i18n: I18nType,
+  clusterVip: string,
 ): Column<Model> => {
   return {
     key: 'displayPortMapping',
@@ -584,7 +585,7 @@ export const PortMappingColumnRenderer = <Model extends ServiceModel>(
           content={
             <span style={{ whiteSpace: 'pre' }}>
               {record.displayType === 'NodePort' ? (
-                <Link href={`//${v.link}`} target="_blank">
+                <Link href={`//${clusterVip}:${v.nodePort}`} target="_blank">
                   {v.servicePort}
                 </Link>
               ) : (

--- a/packages/refine/src/models/service-model.ts
+++ b/packages/refine/src/models/service-model.ts
@@ -44,6 +44,7 @@ export class ServiceModel extends ResourceModel<ServiceType> {
       }
       return {
         servicePort: p.port,
+        nodePort: p.nodePort,
         link,
         targetPort: p.targetPort,
         protocol: p.protocol,

--- a/packages/refine/src/pages/services/index.tsx
+++ b/packages/refine/src/pages/services/index.tsx
@@ -49,7 +49,7 @@ export const ServicesConfig = (i18n: i18n): ResourceConfig<ServiceModel> => ({
         return <TextTags value={value} />;
       },
     },
-    PortMappingColumnRenderer(i18n),
+    PortMappingColumnRenderer(i18n, '192.168.1.1'),
     AgeColumnRenderer(i18n),
   ],
   showConfig: () => ({


### PR DESCRIPTION
1. 优化yamleditor的报错显示，保留换行格式

![截屏2024-05-16 15 29 55](https://github.com/webzard-io/dovetail-v2/assets/12260952/02b5593b-b099-4b62-a9b9-cae4f83573cd)

2. 修复 Service 的端口映射的显示的bug

![截屏2024-05-16 16 08 06](https://github.com/webzard-io/dovetail-v2/assets/12260952/c902330a-596f-4299-bb6f-8a18e8d072f6)


