### PR TITLE
Bowen/sks 2671 fix

### DIFF
--- a/packages/refine/src/components/ServiceComponents/index.tsx
+++ b/packages/refine/src/components/ServiceComponents/index.tsx
@@ -38,15 +38,22 @@ export const ServiceOutClusterAccessComponent: React.FC<
 
   switch (spec.type) {
     case ServiceTypeEnum.NodePort:
+      if (!breakLine) {
+        content = spec.ports
+          ?.filter(v => !!v)
+          .map(p => `${i18n.t('dovetail.any_node_ip')}:${p.nodePort}`)
+          .join(', ');
+        break;
+      }
+
       content = spec.ports
         ?.filter(v => !!v)
-        .map((p, index) => (
+        .map(p => (
           <OverflowTooltip
             key={p.nodePort}
             content={
               <span className={cx(Typo.Label.l4_regular_title, BreakLineStyle)}>
                 {i18n.t('dovetail.any_node_ip')}:{p.nodePort}
-                {!breakLine && index !== (spec.ports || []).length - 1 ? ', ' : ''}
               </span>
             }
             tooltip={`${i18n.t('dovetail.any_node_ip')}:${p.nodePort}`}
@@ -56,24 +63,26 @@ export const ServiceOutClusterAccessComponent: React.FC<
     case ServiceTypeEnum.ExternalName:
       content = (
         <ValueDisplay
+          useOverflow={false}
           value={spec.externalIPs?.join(breakLine ? '\n' : ', ')}
-        ></ValueDisplay>
+        />
       );
       break;
     case ServiceTypeEnum.LoadBalancer:
       content = (
         <ValueDisplay
+          useOverflow={false}
           value={status.loadBalancer?.ingress
             ?.map(({ ip }) => ip)
             .join(breakLine ? '\n' : ', ')}
-        ></ValueDisplay>
+        />
       );
       break;
     case ServiceTypeEnum.ClusterIP:
       content = i18n.t('dovetail.not_support');
       break;
     default:
-      content = <ValueDisplay value=""></ValueDisplay>;
+      content = <ValueDisplay useOverflow={false} value="" />;
       break;
   }
 

--- a/packages/refine/src/components/YamlEditor/MonacoYamlEditor.tsx
+++ b/packages/refine/src/components/YamlEditor/MonacoYamlEditor.tsx
@@ -87,6 +87,7 @@ const MonacoYamlEditor: React.FC<Props> = props => {
       model,
       scrollbar: {
         handleMouseWheel: !isScrollOnFocus,
+        alwaysConsumeMouseWheel: false, // https://github.com/microsoft/monaco-editor/issues/2007
       },
       tabSize: 2,
       readOnly: readOnly,


### PR DESCRIPTION
1. 修复 ServiceOutClusterAccess 里面的换行+逗号问题，应该不换行
2. 修复 monaco editor 滚动事件不会冒泡的问题

![截屏2024-05-23 14 28 06](https://github.com/webzard-io/dovetail-v2/assets/12260952/5bee869d-1d33-49f1-9049-f8a6ba07960f)
![截屏2024-05-23 14 27 49](https://github.com/webzard-io/dovetail-v2/assets/12260952/e3cd8c24-97ef-42f3-90a9-75136e76e694)
