### PR TITLE
fix: don't open toast when getting data fails

### DIFF
--- a/packages/refine/src/Dovetail.tsx
+++ b/packages/refine/src/Dovetail.tsx
@@ -58,6 +58,10 @@ export const Dovetail: React.FC<Props> = props => {
     type NoticeType = 'info' | 'success' | 'error' | 'warning' | 'loading';
     const provider: NotificationProvider = {
       open: ({ message, key, type }) => {
+        const EXCLUDE = ['getList', 'getOne', 'getMany'];
+
+        if (EXCLUDE.some(excludeKey => key?.includes(excludeKey))) return;
+
         msg.open({
           content: message,
           key,

--- a/packages/refine/src/components/PageShow/PageShow.tsx
+++ b/packages/refine/src/components/PageShow/PageShow.tsx
@@ -23,6 +23,7 @@ export const PageShow = <Model extends ResourceModel>(props: Props<Model>) => {
     },
     errorNotification: () => {
       return {
+        key: 'resource-non-exist',
         message: i18n.t('dovetail.fail_get_detail', {
           resource: resource?.name,
           name: parsed?.params?.id,


### PR DESCRIPTION
除详情页获取失败时会提示「资源不存在」，其他情况下获取数据失败不再进行提示