### PR TITLE
SKS-2783 add port in ingress rule

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/src/models/ingress-model.ts
+++ b/packages/refine/src/models/ingress-model.ts
@@ -57,9 +57,6 @@ export class IngressModel extends ResourceModel<IngressTypes> {
     const hostValue = rule.host || '';
     const protocal = this._rawYaml.spec.tls ? 'https://' : 'http://';
     const portText = port ? `:${port}` : '';
-    if (path[path.length - 1] === '/') {
-      path = path.slice(0, -1);
-    }
-    return `${protocal}${hostValue}${path}${portText}`;
+    return `${protocal}${hostValue}${portText}${path}`;
   }
 }


### PR DESCRIPTION
启用 Contour 时，contour-envoy 服务的 type 设置为 NodePort 时，Ingress 的规则中请求端后面要加上端口
![截屏2024-06-05 11 17 29](https://github.com/webzard-io/dovetail-v2/assets/12260952/5a39552b-0f89-4eac-abf6-8b93dfc47718)

