### PR TITLE
feat: support chagne the ui form to yaml editor

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -52,6 +52,10 @@
     "@linaria/core": "^4.5.4",
     "@linaria/react": "^4.5.4",
     "@linaria/vite": "^4.5.4",
+    "@linaria/babel-preset": "^4.5.4",
+    "@linaria/logger": "^4.5.0",
+    "@linaria/utils": "^4.5.3",
+    "@rollup/pluginutils": "^4.2.1",
     "@playwright/test": "^1.39.0",
     "@refinedev/cli": "^2.9.0",
     "@types/body-parser": "^1.19.5",
@@ -73,6 +77,7 @@
     "eslint-plugin-react-refresh": "^0.3.4",
     "jest": "^29",
     "kubernetes-types": "^1.26.0",
+    "sass": "1.51.0",
     "ts-jest": "^29",
     "vite": "^4.5.2",
     "vite-plugin-commonjs": "^0.10.0"

--- a/packages/refine/src/App.tsx
+++ b/packages/refine/src/App.tsx
@@ -66,7 +66,7 @@ function App() {
           renderForm: (formProps: YamlFormProps) => (
             <YamlForm
               {...formProps}
-              initialValues={DEPLOYMENT_INIT_VALUE}
+              initialValuesForCreate={DEPLOYMENT_INIT_VALUE}
               isShowLayout={false}
             />
           ),
@@ -107,6 +107,7 @@ function App() {
           useFormProps: {
             mode: 'onTouched',
           },
+          isDisabledChangeMode: true,
           fields: () => [
             {
               path: ['metadata', 'name'],

--- a/packages/refine/src/components/EditField/index.tsx
+++ b/packages/refine/src/components/EditField/index.tsx
@@ -5,7 +5,7 @@ import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FormErrorAlert } from 'src/components/FormErrorAlert';
 import { AccessControlAuth } from 'src/constants/auth';
-import { ModalStyle } from 'src/hooks/useDeleteModal';
+import { SmallModalStyle } from 'src/styles/modal';
 import { useSubmitForm } from 'src/hooks/useSubmitForm';
 
 const EditButtonStyle = css`
@@ -49,7 +49,7 @@ export function EditFieldModal(props: EditFieldModalProps) {
 
   return (
     <Modal
-      className={ModalStyle}
+      className={SmallModalStyle}
       title={title || i18n.t('dovetail.edit')}
       confirmLoading={submitting}
       onOk={onSubmit}

--- a/packages/refine/src/components/Form/RefineFormContent.tsx
+++ b/packages/refine/src/components/Form/RefineFormContent.tsx
@@ -1,12 +1,12 @@
 import { Fields, Form, Space, Typo } from '@cloudtower/eagle';
 import { css, cx } from '@linaria/core';
-import { useList, useShow } from '@refinedev/core';
 import { UseFormReturnType } from '@refinedev/react-hook-form';
 import React from 'react';
 import { Controller } from 'react-hook-form';
-import { ResourceModel } from '../../models';
-import { ResourceConfig } from '../../types';
+import { ResourceModel } from 'src/models';
+import { ResourceConfig } from 'src/types';
 import { FormErrorAlert } from '../FormErrorAlert';
+import useFieldsConfig from './useFieldsConfig';
 
 type Props<Model extends ResourceModel> = {
   config?: ResourceConfig<Model>;
@@ -19,24 +19,8 @@ export const RefineFormContent = <Model extends ResourceModel>(props: Props<Mode
   const { config, formResult, resourceId, errorMsg } = props;
   const { control, getValues } = formResult;
   const action = resourceId ? 'edit' : 'create';
-  const listQuery = useList<Model>({
-    resource: config?.name,
-    meta: { resourceBasePath: config?.basePath, kind: config?.kind },
-    pagination: {
-      mode: 'off',
-    },
-  });
-  const showQuery = useShow<Model>({
-    resource: config?.name,
-    meta: { resourceBasePath: config?.basePath, kind: config?.kind },
-    id: resourceId,
-  });
 
-  const formFieldsConfig = config?.formConfig?.fields?.({
-    record: showQuery.queryResult.data?.data,
-    records: listQuery.data?.data || [],
-    action,
-  });
+  const formFieldsConfig = useFieldsConfig(config, resourceId);
 
   const fields = formFieldsConfig?.map(c => {
     return (
@@ -136,7 +120,6 @@ export const RefineFormContent = <Model extends ResourceModel>(props: Props<Mode
       size={16}
       className={css`
         flex-basis: 58%;
-        max-width: 648px;
         width: 100%;
         margin: 0 auto;
       `}

--- a/packages/refine/src/components/Form/YamlForm.tsx
+++ b/packages/refine/src/components/Form/YamlForm.tsx
@@ -11,6 +11,7 @@ import { YamlEditorComponent } from 'src/components/YamlEditor/YamlEditorCompone
 import { BASE_INIT_VALUE } from 'src/constants/k8s';
 import { getCommonErrors } from 'src/utils/error';
 import useYamlForm from './useYamlForm';
+import { YamlFormRule } from './useYamlForm';
 
 const FormStyle = css``;
 const EditorStyle = css`
@@ -28,10 +29,12 @@ export enum SchemaStrategy {
 export interface YamlFormProps {
   id?: string;
   action?: FormAction;
-  initialValues?: Record<string, unknown>;
+  initialValuesForCreate?: Record<string, unknown>;
+  initialValuesForEdit?: Record<string, unknown>;
   schemaStrategy?: SchemaStrategy;
   isShowLayout?: boolean;
   useFormProps?: Parameters<typeof useYamlForm>[0];
+  rules?: YamlFormRule[];
   transformInitValues?: (values: Unstructured) => Unstructured;
   transformApplyValues?: (values: Unstructured) => Unstructured;
   onSaveButtonPropsChange?: (saveButtonProps: {
@@ -53,7 +56,8 @@ export function YamlForm(props: YamlFormProps) {
     transformInitValues,
     transformApplyValues,
     onSaveButtonPropsChange,
-    onErrorsChange
+    onErrorsChange,
+    rules,
   } = props;
   const { action: actionFromResource, resource } = useResource();
   const action = actionFromProps || actionFromResource;
@@ -73,7 +77,9 @@ export function YamlForm(props: YamlFormProps) {
       isSkipSchema: schemaStrategy === SchemaStrategy.None,
     },
     liveMode: 'off',
-    initialValuesForCreate: props.initialValues ?? BASE_INIT_VALUE,
+    initialValuesForCreate: props.initialValuesForCreate ?? BASE_INIT_VALUE,
+    initialValuesForEdit: props.initialValuesForEdit,
+    rules,
     successNotification(data) {
       return {
         message: i18n.t(action === 'create' ? 'dovetail.create_success_toast' : 'dovetail.save_yaml_success_toast', {

--- a/packages/refine/src/components/Form/useFieldsConfig.ts
+++ b/packages/refine/src/components/Form/useFieldsConfig.ts
@@ -1,0 +1,27 @@
+import { ResourceModel } from 'src/models';
+import { useList, useShow } from '@refinedev/core';
+import { ResourceConfig } from 'src/types';
+
+function useFieldsConfig<Model extends ResourceModel>(config?: ResourceConfig<Model>, resourceId?: string) {
+  const action = resourceId ? 'edit' : 'create';
+  const listQuery = useList<Model>({
+    resource: config?.name,
+    meta: { resourceBasePath: config?.basePath, kind: config?.kind },
+    pagination: {
+      mode: 'off',
+    },
+  });
+  const showQuery = useShow<Model>({
+    resource: config?.name,
+    meta: { resourceBasePath: config?.basePath, kind: config?.kind },
+    id: resourceId,
+  });
+
+  return config?.formConfig?.fields?.({
+    record: showQuery.queryResult.data?.data,
+    records: listQuery.data?.data || [],
+    action,
+  });
+}
+
+export default useFieldsConfig;

--- a/packages/refine/src/components/NamespacesFilter/index.tsx
+++ b/packages/refine/src/components/NamespacesFilter/index.tsx
@@ -40,7 +40,7 @@ const DropdownStyle = css`
   border-radius: 6px;
 `;
 const SearchInputStyle = css`
-  &&.ant-input-affix-wrapper {
+  &.ant-input-affix-wrapper.ant-input-affix-wrapper {
     border: unset;
     border-bottom: 1px solid rgba(211, 218, 235, .6);
     border-radius: unset;

--- a/packages/refine/src/components/ValueDisplay/index.tsx
+++ b/packages/refine/src/components/ValueDisplay/index.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 const EMPTY_VALUES: unknown[] = [undefined, null, '', '-'];
 
 const EmptyStyle = css`
-  && {
+  &.empty-text {
     color: rgba(0,21,64,.3);
   }
 `;
@@ -29,7 +29,7 @@ export function ValueDisplay(props: ValueDisplayProps) {
   const { value, useOverflow = true, className, style } = props;
 
   return EMPTY_VALUES.includes(value) ? (
-    <div className={cx(EmptyStyle, className)} style={style}>-</div>
+    <div className={cx(EmptyStyle, 'empty-text', className)} style={style}>-</div>
   ) : (
     <div
       style={style}

--- a/packages/refine/src/hooks/useDeleteModal/useDeleteModal.tsx
+++ b/packages/refine/src/hooks/useDeleteModal/useDeleteModal.tsx
@@ -4,6 +4,7 @@ import { useDelete, useNavigation } from '@refinedev/core';
 import React, { useState, useContext } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import ConfigsContext from 'src/contexts/configs';
+import { SmallModalStyle } from 'src/styles/modal';
 
 const TextStyle = css`
   margin-bottom: 4px;
@@ -22,35 +23,6 @@ const NameStyle = css`
     font-weight: bold;
   }
 `;
-export const ModalStyle = css`
-&.ant-modal.normal-modal {
-  .ant-modal-content {
-    width: 492px;
-    border-radius: 16px;
-  }
-
-  .ant-modal-body {
-    padding: 32px 40px;
-    min-height: 160px;
-    overflow-x: hidden;
-  }
-
-  .ant-modal-header {
-    border-radius: 16px 16px 0 0;
-    padding: 32px 40px;
-    padding-bottom: 0;
-  }
-
-  .ant-modal-footer {
-    padding: 24px 40px;
-  }
-
-  .ant-modal-close-x {
-    top: 35px;
-    right: 40px;
-  }
-}
-`;
 
 export const useDeleteModal = (resource: string) => {
   const configs = useContext(ConfigsContext);
@@ -62,7 +34,7 @@ export const useDeleteModal = (resource: string) => {
   const [id, setId] = useState<string>('');
   const { t } = useTranslation();
   const modalProps: ModalProps = {
-    className: ModalStyle,
+    className: SmallModalStyle,
     title: t('dovetail.delete_resource', { resource: config.kind }),
     okText: t('dovetail.delete'),
     okButtonProps: {

--- a/packages/refine/src/hooks/useSchema.ts
+++ b/packages/refine/src/hooks/useSchema.ts
@@ -89,7 +89,7 @@ export function useSchema(options?: UseSchemaOptions): UseSchemaResult {
     } finally {
       setLoading(false);
     }
-  }, [resource, openapi]);
+  }, [resource?.meta?.kind, openapi]);
 
   useEffect(() => {
     if (options?.skip) return;

--- a/packages/refine/src/locales/zh-CN/dovetail.json
+++ b/packages/refine/src/locales/zh-CN/dovetail.json
@@ -175,5 +175,9 @@
   "disconnected": "连接异常。",
   "connecting": "正在连接...",
   "reconnect": "重新连接",
-  "search": "搜索"
+  "search": "搜索",
+  "edit_form": "编辑表单",
+  "exit_yaml_tip": "返回编辑表单，不会保留对 YAML 文件做出的所有更改。",
+  "form": "表单",
+  "yaml": "YAML"
 }

--- a/packages/refine/src/pages/cronjobs/create/index.tsx
+++ b/packages/refine/src/pages/cronjobs/create/index.tsx
@@ -4,5 +4,5 @@ import { YamlForm } from 'src/components';
 import { CRONJOB_INIT_VALUE } from 'src/constants/k8s';
 
 export const CronJobForm: React.FC<FormProps> = () => {
-  return <YamlForm initialValues={CRONJOB_INIT_VALUE} />;
+  return <YamlForm initialValuesForCreate={CRONJOB_INIT_VALUE} />;
 };

--- a/packages/refine/src/pages/daemonsets/create/index.tsx
+++ b/packages/refine/src/pages/daemonsets/create/index.tsx
@@ -4,5 +4,5 @@ import { YamlForm } from 'src/components';
 import { DAEMONSET_INIT_VALUE } from 'src/constants/k8s';
 
 export const DaemonSetForm: React.FC<FormProps> = () => {
-  return <YamlForm initialValues={DAEMONSET_INIT_VALUE} />;
+  return <YamlForm initialValuesForCreate={DAEMONSET_INIT_VALUE} />;
 };

--- a/packages/refine/src/pages/pods/create/index.tsx
+++ b/packages/refine/src/pages/pods/create/index.tsx
@@ -4,5 +4,5 @@ import { YamlForm } from 'src/components';
 import { POD_INIT_VALUE } from 'src/constants/k8s';
 
 export const PodForm: React.FC<FormProps> = () => {
-  return <YamlForm initialValues={POD_INIT_VALUE} />;
+  return <YamlForm initialValuesForCreate={POD_INIT_VALUE} />;
 };

--- a/packages/refine/src/styles/button.ts
+++ b/packages/refine/src/styles/button.ts
@@ -1,0 +1,11 @@
+import { css } from '@linaria/core';
+
+export const WarningButtonStyle = css`
+  &.ant-btn.ant-btn.ant-btn-primary {
+    background-color: $yellow-60;
+
+    &:hover {
+      background-color: $yellow-40;
+    }
+  }
+`;

--- a/packages/refine/src/styles/modal.ts
+++ b/packages/refine/src/styles/modal.ts
@@ -4,17 +4,56 @@ import { css } from '@linaria/core';
 export const FullscreenModalStyle = css`
   &.ant-modal.fullscreen {
     .ant-modal-header {
-      padding: 60px 128px 32px 128px;
+      padding: 60px 0 32px 0;
+      max-width: var(--max-modal-width, 1024px);
+      width: 100%;
+      margin: auto;
     }
 
     .ant-modal-body {
-      padding: 0 128px;
+      padding: 0 4px;
+      max-width: var(--max-modal-width, 1024px);
+      width: 100%;
+      margin: auto;
     }
 
     .ant-modal-footer {
       .footer-content {
-        margin: 0 128px;
+        padding: 0;
+        max-width: var(--max-modal-width, 1024px);
+        width: 100%;
+        margin: auto;
       }
     }
   }
+`;
+
+export const SmallModalStyle = css`
+&.ant-modal.normal-modal {
+  .ant-modal-content {
+    width: 492px;
+    border-radius: 16px;
+  }
+
+  .ant-modal-body {
+    padding: 32px 40px;
+    min-height: 160px;
+    overflow-x: hidden;
+  }
+
+  .ant-modal-header {
+    border-radius: 16px 16px 0 0;
+    padding: 32px 40px;
+    padding-bottom: 0;
+  }
+
+  .ant-modal-footer {
+    padding: 24px 40px;
+  }
+
+  .ant-modal-close-x {
+    top: 35px;
+    right: 40px;
+  }
+}
 `;

--- a/packages/refine/src/types/modal.d.ts
+++ b/packages/refine/src/types/modal.d.ts
@@ -1,10 +1,11 @@
 import { ModalType } from '@cloudtower/eagle';
 import { EditFieldModalProps } from 'src/components/EditField';
-import { FormModalProps } from 'src/components/FormModal';
+import { FormModalProps, ConfirmModalProps } from 'src/components/FormModal';
 import { PodShellModal } from 'src/components/PodShellModal';
 
 type ModalProps = {
   FormModal: FormModalProps;
+  ConfirmModal: ConfirmModalProps;
   EditFieldModal: EditFieldModalProps;
   PodShellModal: PodShellModal;
 };

--- a/packages/refine/src/types/resource.ts
+++ b/packages/refine/src/types/resource.ts
@@ -55,8 +55,9 @@ export type ResourceConfig<Model extends ResourceModel = ResourceModel> = {
     transformApplyValues?: (values: Unstructured) => Unstructured;
     formTitle?: string | ((action: 'create' | 'edit') => string);
     formDesc?: string | ((action: 'create' | 'edit') => string);
-    formatError?: (errorBody: any) => string;
+    formatError?: (errorBody: unknown) => string;
     refineCoreProps?: UseFormProps['refineCoreProps'];
     useFormProps?: UseFormProps;
+    isDisabledChangeMode?: boolean;
   };
 };

--- a/packages/refine/tools/linaria.ts
+++ b/packages/refine/tools/linaria.ts
@@ -1,0 +1,212 @@
+/** from: https://github.com/callstack/linaria/blob/linaria%404.5.4/packages/vite/src/index.ts */
+/**
+ * This file contains a Rollup loader for Linaria.
+ * It uses the transform.ts function to generate class names from source code,
+ * returns transformed code without template literals and attaches generated source maps
+ */
+
+import path from 'path';
+
+
+import {
+  transform,
+  slugify,
+  TransformCacheCollection,
+} from '@linaria/babel-preset';
+import type { PluginOptions, Preprocessor } from '@linaria/babel-preset';
+import { createCustomDebug } from '@linaria/logger';
+import type { IPerfMeterOptions } from '@linaria/utils';
+import { createPerfMeter, getFileIdx, syncResolve } from '@linaria/utils';
+import type { FilterPattern } from '@rollup/pluginutils';
+import { createFilter } from '@rollup/pluginutils';
+import type { ModuleNode, Plugin, ResolvedConfig, ViteDevServer } from 'vite';
+
+type VitePluginOptions = {
+  debug?: IPerfMeterOptions | false | null | undefined;
+  include?: FilterPattern;
+  exclude?: FilterPattern;
+  sourceMap?: boolean;
+  preprocessor?: Preprocessor;
+  extension?: string;
+} & Partial<PluginOptions>;
+
+export { Plugin };
+
+const emptyConfig = {};
+
+export default function linaria({
+  debug,
+  include,
+  exclude,
+  sourceMap,
+  preprocessor,
+  extension = 'css',
+  ...rest
+}: VitePluginOptions = {}): Plugin {
+  const filter = createFilter(include, exclude);
+  const cssLookup: { [key: string]: string } = {};
+  const cssFileLookup: { [key: string]: string } = {};
+  let config: ResolvedConfig;
+  let devServer: ViteDevServer;
+
+  const { emitter, onDone } = createPerfMeter(debug ?? false);
+
+  // <dependency id, targets>
+  const targets: { id: string; dependencies: string[] }[] = [];
+  const cache = new TransformCacheCollection();
+  return {
+    name: 'linaria',
+    enforce: 'post',
+    buildEnd() {
+      onDone(process.cwd());
+    },
+    configResolved(resolvedConfig: ResolvedConfig) {
+      config = resolvedConfig;
+    },
+    configureServer(_server) {
+      devServer = _server;
+    },
+    load(url: string) {
+      const [id] = url.split('?', 1);
+      return cssLookup[id];
+    },
+    /* eslint-disable-next-line consistent-return */
+    resolveId(importeeUrl: string) {
+      const [id] = importeeUrl.split('?', 1);
+      if (cssLookup[id]) return id;
+      return cssFileLookup[id];
+    },
+    handleHotUpdate(ctx) {
+      // it's module, so just transform it
+      if (ctx.modules.length) return ctx.modules;
+
+      // Select affected modules of changed dependency
+      const affected = targets.filter(
+        (x) =>
+          // file is dependency of any target
+          x.dependencies.some((dep) => dep === ctx.file) ||
+          // or changed module is a dependency of any target
+          x.dependencies.some((dep) => ctx.modules.some((m) => m.file === dep))
+      );
+      const deps = affected.flatMap((target) => target.dependencies);
+
+      // eslint-disable-next-line no-restricted-syntax
+      for (const depId of deps) {
+        cache.invalidateForFile(depId);
+      }
+
+      const modules = affected
+        .map((target) => devServer.moduleGraph.getModuleById(target.id))
+        .concat(ctx.modules)
+        .filter((m): m is ModuleNode => !!m);
+
+      return modules;
+    },
+    async transform(code: string, url: string) {
+      const [id] = url.split('?', 1);
+
+      // Do not transform ignored and generated files
+      if (url.includes('node_modules') || !filter(url) || id in cssLookup)
+        return;
+
+      const log = createCustomDebug('rollup', getFileIdx(id));
+
+      log('rollup-init', id);
+
+      const asyncResolve = async (
+        what: string,
+        importer: string,
+        stack: string[]
+      ) => {
+        const resolved = await this.resolve(what, importer);
+        if (resolved) {
+          if (resolved.external) {
+            // If module is marked as external, Rollup will not resolve it,
+            // so we need to resolve it ourselves with default resolver
+            const resolvedId = syncResolve(what, importer, stack);
+            log('resolve', '✅ \'%s\'@\'%s -> %O\n%s', what, importer, resolved);
+            return resolvedId;
+          }
+
+          log('resolve', '✅ \'%s\'@\'%s -> %O\n%s', what, importer, resolved);
+          // Vite adds param like `?v=667939b3` to cached modules
+          const resolvedId = resolved.id.split('?', 1)[0];
+
+          if (resolvedId.startsWith('\0')) {
+            // \0 is a special character in Rollup that tells Rollup to not include this in the bundle
+            // https://rollupjs.org/guide/en/#outputexports
+            return null;
+          }
+
+          return resolvedId;
+        }
+
+        log('resolve', '❌ \'%s\'@\'%s', what, importer);
+        throw new Error(`Could not resolve ${what}`);
+      };
+
+      const result = await transform(
+        code,
+        {
+          filename: id,
+          preprocessor,
+          pluginOptions: rest,
+        },
+        asyncResolve,
+        emptyConfig,
+        cache,
+        emitter
+      );
+
+      let { cssText, dependencies } = result;
+
+      if (!cssText) return;
+      dependencies ??= [];
+
+      const slug = slugify(cssText);
+
+      const cssFilename = path
+        .normalize(`${id.replace(/\.[jt]sx?$/, '')}_${slug}.${extension}`)
+        .replace(/\\/g, path.posix.sep);
+
+
+      const cssRelativePath = path
+        .relative(config.root, cssFilename)
+        .replace(/\\/g, path.posix.sep);
+
+      const cssId = `/${cssRelativePath}`;
+
+      if (sourceMap && result.cssSourceMapText) {
+        const map = Buffer.from(result.cssSourceMapText).toString('base64');
+        cssText += `/*# sourceMappingURL=data:application/json;base64,${map}*/`;
+      }
+
+      cssLookup[cssFilename] = cssText;
+      cssFileLookup[cssId] = cssFilename;
+
+      result.code += `\nimport ${JSON.stringify(cssFilename)};\n`;
+      if (devServer?.moduleGraph) {
+        const module = devServer.moduleGraph.getModuleById(cssId);
+
+        if (module) {
+          devServer.moduleGraph.invalidateModule(module);
+          module.lastHMRTimestamp =
+            module.lastInvalidationTimestamp || Date.now();
+        }
+      }
+
+      for (let i = 0, end = dependencies.length; i < end; i++) {
+        // eslint-disable-next-line no-await-in-loop
+        const depModule = await this.resolve(dependencies[i], url, {
+          isEntry: false,
+        });
+        if (depModule) dependencies[i] = depModule.id;
+      }
+      const target = targets.find((t) => t.id === id);
+      if (!target) targets.push({ id, dependencies });
+      else target.dependencies = dependencies;
+      /* eslint-disable-next-line consistent-return */
+      return { code: result.code, map: result.sourceMap };
+    },
+  };
+}

--- a/packages/refine/tsconfig.json
+++ b/packages/refine/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "vite.config.ts"],
+  "include": [
+    "src"
+  ],
   "references": [
     {
       "path": "./tsconfig.node.json"
@@ -8,7 +10,9 @@
   ],
   "compilerOptions": {
     "paths": {
-      "src/*": ["./src/*"]
+      "src/*": [
+        "./src/*"
+      ]
     },
     "declaration": true,
     "declarationDir": "lib"

--- a/packages/refine/vite.config.ts
+++ b/packages/refine/vite.config.ts
@@ -1,14 +1,17 @@
 import path from 'path';
-import linaria from '@linaria/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import commonjs from 'vite-plugin-commonjs';
+import linaria from './tools/linaria';
 
 export default defineConfig({
   plugins: [
     commonjs(),
     react(),
-    linaria(),
+    linaria({
+      preprocessor: 'none',
+      extension: 'scss'
+    }),
   ],
   optimizeDeps: {
     exclude: ['monaco-yaml/yaml.worker.js']
@@ -75,4 +78,11 @@ export default defineConfig({
       src: path.resolve(__dirname, 'src'),
     },
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        additionalData: '@import "@cloudtower/eagle/dist/variables.scss";\r\n'
+      }
+    }
+  }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2780,7 +2780,7 @@
     lodash-es "^4.17.21"
     react-hook-form "^7.30.0"
 
-"@rollup/pluginutils@^4.1.0":
+"@rollup/pluginutils@^4.1.0", "@rollup/pluginutils@^4.2.1":
   version "4.2.1"
   resolved "https://registry.npmmirror.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
   integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
@@ -3671,7 +3671,7 @@ any-promise@^1.0.0:
   resolved "https://registry.npmmirror.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
   integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
 
-anymatch@^3.0.3:
+anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.npmmirror.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
@@ -4103,6 +4103,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+binary-extensions@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
+  integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
+
 bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmmirror.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
@@ -4199,6 +4204,13 @@ braces@^3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+braces@~3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
+  dependencies:
+    fill-range "^7.1.1"
 
 browserslist@^4.21.10, browserslist@^4.21.9:
   version "4.21.10"
@@ -4424,6 +4436,21 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.npmmirror.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+"chokidar@>=3.0.0 <4.0.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 chownr@^2.0.0:
   version "2.0.0"
@@ -6149,6 +6176,13 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
+  dependencies:
+    to-regex-range "^5.0.1"
+
 finalhandler@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmmirror.com/finalhandler/-/finalhandler-1.2.0.tgz#7d23fe5731b207b4640e4fcd00aec1f9207a7b32"
@@ -6478,7 +6512,7 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -6849,6 +6883,11 @@ ignore@^5.2.0, ignore@^5.2.4:
   resolved "https://registry.npmmirror.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
+immutable@^4.0.0:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.7.tgz#c70145fc90d89fb02021e65c84eb0226e4e5a381"
+  integrity sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmmirror.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
@@ -7087,6 +7126,13 @@ is-bigint@^1.0.1:
   dependencies:
     has-bigints "^1.0.1"
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-boolean-object@^1.1.0:
   version "1.1.2"
   resolved "https://registry.npmmirror.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719"
@@ -7219,7 +7265,7 @@ is-generator-function@^1.0.10:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -8955,7 +9001,7 @@ normalize-package-data@^3.0.0:
     semver "^7.3.4"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^3.0.0:
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.npmmirror.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -9354,7 +9400,7 @@ picocolors@^1.0.0:
   resolved "https://registry.npmmirror.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.2, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -10669,6 +10715,13 @@ readable-stream@~2.3.6:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
+
 recast@^0.20.4:
   version "0.20.5"
   resolved "https://registry.npmmirror.com/recast/-/recast-0.20.5.tgz#8e2c6c96827a1b339c634dd232957d230553ceae"
@@ -11085,6 +11138,15 @@ safe-regex@^1.1.0:
   resolved "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sass@1.51.0:
+  version "1.51.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.51.0.tgz#25ea36cf819581fe1fe8329e8c3a4eaaf70d2845"
+  integrity sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+    immutable "^4.0.0"
+    source-map-js ">=0.6.2 <2.0.0"
+
 scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.npmmirror.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
@@ -11298,6 +11360,11 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+"source-map-js@>=0.6.2 <2.0.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
 source-map-js@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
支持表单模式转换为 YAML 编辑模式。

### 表单 -> YAML
将表单当前值作为初始值赋给 YAML 编辑器，并在提交时进行 YAML 格式、Schema 和自定义逻辑校验。

### YAML -> 表单
会提示转换为表单后 YAML 编辑器所填内容会丢失，转换后会回到之前表单所填写的值。

主要代码在 useYamlForm。

![image](https://github.com/user-attachments/assets/1a2cdc42-b1dd-4dde-b4dd-8b303c99d10d)

![image](https://github.com/user-attachments/assets/426440e2-389f-4d23-8485-eb64e3a28e08)

![image](https://github.com/user-attachments/assets/8b38cc75-9f13-439e-8958-585625510cc1)

![image](https://github.com/user-attachments/assets/78e578cc-b2ac-4c81-a39f-81f9b5357560)
