### PR TITLE
fix: fix useApiGroupSchema refresh bug

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -78,8 +78,8 @@
     "vite-plugin-commonjs": "^0.10.0"
   },
   "peerDependencies": {
-    "@cloudtower/eagle": "^0.31.7",
-    "@cloudtower/icons-react": "^0.31.7",
+    "@cloudtower/eagle": "^0.31.8",
+    "@cloudtower/icons-react": "^0.31.8",
     "@refinedev/core": "^4.47.2",
     "antd": "4.5.0",
     "i18next": "^23.2.3",

--- a/packages/refine/src/components/index.ts
+++ b/packages/refine/src/components/index.ts
@@ -4,6 +4,7 @@ export * from './PageShow';
 export * from './Time';
 export * from './ConditionsTable';
 export * from './FormLayout';
+export * from './FormErrorAlert';
 export * from './PodContainersTable';
 export * from './WorkloadDropdown';
 export * from './ReplicasDropdown';

--- a/packages/refine/src/hooks/useSchema.ts
+++ b/packages/refine/src/hooks/useSchema.ts
@@ -15,7 +15,7 @@ type UseSchemaResult = {
   fetchSchema: () => void;
 };
 
-export function useApiGroupSchema(apiGroups: string[]) {
+export function useApiGroupSchema() {
   const [state, setState] = useState<{
     schemas: JSONSchema7[] | null;
     schemasMap: Record<string, JSONSchema7[]>;
@@ -28,7 +28,7 @@ export function useApiGroupSchema(apiGroups: string[]) {
     error: null,
   });
 
-  const fetchSchema = useCallback(async () => {
+  const fetchSchema = useCallback(async (apiGroups: string[]) => {
     setState(prev => ({ ...prev, loading: true, error: null }));
 
     try {
@@ -59,11 +59,7 @@ export function useApiGroupSchema(apiGroups: string[]) {
     } catch (e) {
       setState(prev => ({ ...prev, loading: false, error: e as Error }));
     }
-  }, [apiGroups, state.schemasMap]);
-
-  useEffect(() => {
-    fetchSchema();
-  }, [fetchSchema]);
+  }, [state.schemasMap]);
 
   return { ...state, fetchSchema };
 }


### PR DESCRIPTION
把apiGroups作为参数传给fetchSchema，以免每次apiGroups变化，hooks都重新执行。