### PR TITLE
fix: monaco editor show line number digits up to 7

### DIFF
--- a/packages/refine/src/components/YamlEditor/MonacoYamlEditor.tsx
+++ b/packages/refine/src/components/YamlEditor/MonacoYamlEditor.tsx
@@ -87,6 +87,7 @@ const MonacoYamlEditor: React.FC<Props> = props => {
         alwaysConsumeMouseWheel: false, // https://github.com/microsoft/monaco-editor/issues/2007
       },
       tabSize: 2,
+      lineNumbersMinChars: 7,
       readOnly: readOnly,
       autoIndent: import.meta.env.VITE_IS_TEST ? 'none' : 'advanced',
     });


### PR DESCRIPTION
让editor支持显示更大的代码行数位数。本来是5，改成7。