### PR TITLE
fix: fix onItemHover is not a function bug

### DIFF
--- a/packages/refine/src/components/DropdownMenuItems/EditAnnotationDropdownMenuItem.tsx
+++ b/packages/refine/src/components/DropdownMenuItems/EditAnnotationDropdownMenuItem.tsx
@@ -21,6 +21,7 @@ export function EditAnnotationDropdownMenuItem<Model extends ResourceModel>(
   const pushModal = usePushModal();
   return (
     <Menu.Item
+      {...props}
       className="ant-dropdown-menu-item"
       onClick={() => {
         const modalProps = {

--- a/packages/refine/src/components/DropdownMenuItems/EditLabelDropdownMenuItem.tsx
+++ b/packages/refine/src/components/DropdownMenuItems/EditLabelDropdownMenuItem.tsx
@@ -21,6 +21,7 @@ export function EditLabelDropdownMenuItem<Model extends ResourceModel>(
   const pushModal = usePushModal();
   return (
     <Menu.Item
+      {...props}
       className="ant-dropdown-menu-item"
       onClick={() => {
         const modalProps = {

--- a/packages/refine/src/components/DropdownMenuItems/EditNodeTaintDropdownMenuItem.tsx
+++ b/packages/refine/src/components/DropdownMenuItems/EditNodeTaintDropdownMenuItem.tsx
@@ -23,6 +23,7 @@ export function EditNodeTaintDropdownMenuItem(
   const pushModal = usePushModal();
   return (
     <Menu.Item
+      {...props}
       className="ant-dropdown-menu-item"
       onClick={() => {
         const modalProps = {


### PR DESCRIPTION
修复一个已知问题，鼠标hover到dropdown item上面的时候，会出现 Uncaught TypeError: onItemHover is not a function。

![截屏2024-10-24 10 49 27](https://github.com/user-attachments/assets/07677c16-498a-401f-a20f-88ff189395ff)


经查，这个只会出现在自定义MenuItem组件中，原因是props传递的时候丢失了。所以自定义的MenuItem组件需要把props透传给 Menu.item 组件。
https://github.com/react-component/menu/issues/142#issuecomment-413041068

