### PR TITLE
fix: update validators to include form mode parameter

### DIFF
--- a/packages/refine/src/components/Form/RefineFormContent.tsx
+++ b/packages/refine/src/components/Form/RefineFormContent.tsx
@@ -33,7 +33,7 @@ export const RefineFormContent = <Model extends ResourceModel>(props: Props<Mode
             const formValue = getValues();
             if (!c.validators || c.validators.length === 0) return true;
             for (const func of c.validators) {
-              const { isValid, errorMsg } = func(value, formValue);
+              const { isValid, errorMsg } = func(value, formValue, 'form');
               if (!isValid) return errorMsg;
             }
             return true;

--- a/packages/refine/src/components/Form/type.ts
+++ b/packages/refine/src/components/Form/type.ts
@@ -3,7 +3,8 @@ import { Control } from 'react-hook-form';
 
 export type RefineFormValidator = (
   value: unknown,
-  formValue: unknown
+  formValue: unknown,
+  formMode: 'yaml' | 'form'
 ) => { isValid: boolean; errorMsg: string };
 
 export type RefineFormField = {

--- a/packages/refine/src/components/Form/useYamlForm.ts
+++ b/packages/refine/src/components/Form/useYamlForm.ts
@@ -283,7 +283,7 @@ const useYamlForm = <
         const value = get(formValue, path);
 
         for (const validator of (validators || [])) {
-          const { isValid, errorMsg } = validator(value, formValue);
+          const { isValid, errorMsg } = validator(value, formValue, 'yaml');
 
           if (!isValid) {
             errorMap[path.join('.')] = `${errorMsg}(${path.join('.')})`;


### PR DESCRIPTION
在校验函数传入当前的表单模式，以支持在不同模式下使用不同的校验