### PR TITLE
feat: add usePathMap hook for form value transformations

### DIFF
--- a/packages/refine/__tests__/hooks/usePathMap.spec.ts
+++ b/packages/refine/__tests__/hooks/usePathMap.spec.ts
@@ -1,0 +1,178 @@
+import { Unstructured } from 'k8s-api-provider';
+import usePathMap from '../../src/hooks/usePathMap';
+
+interface TestSpec {
+  oldPath?: string;
+  newPath?: string;
+  deep?: {
+    old?: string;
+  };
+  value?: string;
+  mapped?: string;
+}
+
+interface TestConfig {
+  nested?: {
+    new?: string;
+  };
+}
+
+interface TestValues extends Record<string, unknown> {
+  spec?: TestSpec;
+  config?: TestConfig;
+  data?: string;
+  transformed?: string;
+  extra?: string;
+  type?: string;
+  test?: string;
+  _rawYaml?: Record<string, unknown>;
+  parameters?: Record<string, string>;
+}
+
+describe('usePathMap', () => {
+  it('should handle basic path mapping correctly', () => {
+    const pathMap: { from: string[]; to: string[] }[] = [
+      { from: ['spec', 'oldPath'], to: ['spec', 'newPath'] },
+    ];
+
+    const { transformInitValues, transformApplyValues } = usePathMap({ pathMap });
+
+    const initValues: TestValues = {
+      spec: {
+        oldPath: 'value',
+      },
+    };
+
+    const transformedInit = transformInitValues(initValues) as TestValues;
+    expect(transformedInit.spec?.newPath).toBe('value');
+    expect(transformedInit.spec?.oldPath).toBeUndefined();
+
+    const applyValues: TestValues = {
+      spec: {
+        newPath: 'updated-value',
+      },
+    };
+
+    const transformedApply = transformApplyValues(applyValues) as TestValues;
+    expect(transformedApply.spec?.oldPath).toBe('updated-value');
+    expect(transformedApply.spec?.newPath).toBeUndefined();
+  });
+
+  it('should handle nested path mapping correctly', () => {
+    const pathMap: { from: string[]; to: string[] }[] = [
+      { from: ['spec', 'deep', 'old'], to: ['config', 'nested', 'new'] },
+    ];
+
+    const { transformInitValues } = usePathMap({ pathMap });
+
+    const initValues: TestValues = {
+      spec: {
+        deep: {
+          old: 'nested-value',
+        },
+      },
+    };
+
+    const transformedInit = transformInitValues(initValues) as TestValues;
+    expect(transformedInit.config?.nested?.new).toBe('nested-value');
+    expect(transformedInit.spec?.deep?.old).toBeUndefined();
+  });
+
+  it('should support custom transform functions', () => {
+    const pathMap: { from: string[]; to: string[] }[] = [
+      { from: ['data'], to: ['transformed'] },
+    ];
+
+    const customTransform = (values: Record<string, unknown>) => ({
+      ...values,
+      extra: 'custom',
+    });
+
+    const { transformInitValues, transformApplyValues } = usePathMap({
+      pathMap,
+      transformInitValues: customTransform,
+      transformApplyValues: (values) => ({
+        id: 'test-id',
+        apiVersion: 'v1',
+        kind: 'Test',
+        ...values,
+        type: 'Custom',
+      } as unknown as Unstructured),
+    });
+
+    const initValues: TestValues = {
+      data: 'test',
+    };
+
+    const transformedInit = transformInitValues(initValues) as TestValues;
+    expect(transformedInit.transformed).toBe('test');
+    expect(transformedInit.extra).toBe('custom');
+
+    const applyValues: TestValues = {
+      transformed: 'test',
+    };
+
+    const transformedApply = transformApplyValues(applyValues) as TestValues;
+    expect(transformedApply.data).toBe('test');
+    expect(transformedApply.type).toBe('Custom');
+  });
+
+  it('should handle empty mapping correctly', () => {
+    const { transformInitValues, transformApplyValues } = usePathMap({});
+
+    const values: TestValues = {
+      test: 'value',
+    };
+
+    expect(transformInitValues(values)).toEqual(values);
+    expect(transformApplyValues(values)).toEqual(values);
+  });
+
+  it('should handle raw YAML data correctly', () => {
+    const pathMap: { from: string[]; to: string[] }[] = [
+      { from: ['spec', 'value'], to: ['spec', 'mapped'] },
+    ];
+
+    const { transformInitValues } = usePathMap({ pathMap });
+
+    const values: TestValues = {
+      _rawYaml: {
+        spec: {
+          value: 'yaml-value',
+        },
+      },
+    };
+
+    const transformed = transformInitValues(values) as TestValues;
+    expect(transformed.spec?.mapped).toBe('yaml-value');
+    expect(transformed.spec?.value).toBeUndefined();
+  });
+
+  it('should handle StorageClass CSI parameter mapping correctly', () => {
+    const pathMap: { from: string[]; to: string[] }[] = [
+      { from: ['parameters', 'csi.storage.k8s.io/fstype'], to: ['parameters', 'fstype'] },
+    ];
+
+    const { transformInitValues, transformApplyValues } = usePathMap({ pathMap });
+
+    const initValues: TestValues = {
+      parameters: {
+        'csi.storage.k8s.io/fstype': 'ext4',
+      },
+    };
+
+    const transformedInit = transformInitValues(initValues) as TestValues;
+    expect(transformedInit.parameters?.fstype).toBe('ext4');
+    expect(transformedInit.parameters?.['csi.storage.k8s.io/fstype']).toBeUndefined();
+
+    const applyValues: TestValues = {
+      parameters: {
+        fstype: 'xfs',
+      },
+    };
+
+    const transformedApply = transformApplyValues(applyValues) as TestValues;
+    expect(transformedApply.parameters?.['csi.storage.k8s.io/fstype']).toBe('xfs');
+    expect(transformedApply.parameters?.fstype).toBeUndefined();
+  });
+});

--- a/packages/refine/src/components/Form/FormModal.tsx
+++ b/packages/refine/src/components/Form/FormModal.tsx
@@ -7,6 +7,7 @@ import { Unstructured } from 'k8s-api-provider';
 import React, { useState, useContext, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import ConfigsContext from 'src/contexts/configs';
+import usePathMap from 'src/hooks/usePathMap';
 import { WarningButtonStyle } from 'src/styles/button';
 import { FullscreenModalStyle } from 'src/styles/modal';
 import { SmallModalStyle } from 'src/styles/modal';
@@ -108,13 +109,19 @@ export function FormModal(props: FormModalProps) {
       ...config.formConfig?.refineCoreProps,
     },
   });
+  const {
+    transformInitValues,
+    transformApplyValues,
+  } = usePathMap({
+    pathMap: config.formConfig?.pathMap,
+    transformInitValues: config.formConfig?.transformInitValues,
+    transformApplyValues: config.formConfig?.transformApplyValues || ((v: Record<string, unknown>) => v as Unstructured),
+  });
   const yamlFormProps: YamlFormProps = useMemo(
     () => {
-      const transformApplyValues = config.formConfig?.transformApplyValues || ((v: Record<string, unknown>) => v as Unstructured);
-
       return {
         ...props.formProps,
-        transformInitValues: isYamlMode ? undefined : config.formConfig?.transformInitValues,
+        transformInitValues: isYamlMode ? undefined : transformInitValues,
         transformApplyValues: isYamlMode ? undefined : transformApplyValues,
         initialValuesForCreate: isYamlMode ?
           transformApplyValues(refineFormResult.formResult.getValues()) :
@@ -140,8 +147,6 @@ export function FormModal(props: FormModalProps) {
     },
     [
       props.formProps,
-      config.formConfig?.transformInitValues,
-      config.formConfig?.transformApplyValues,
       config?.initValue,
       id,
       action,
@@ -149,6 +154,8 @@ export function FormModal(props: FormModalProps) {
       isYamlMode,
       fieldsConfig,
       popModal,
+      transformInitValues,
+      transformApplyValues,
     ]
   );
 

--- a/packages/refine/src/components/Form/useRefineForm.ts
+++ b/packages/refine/src/components/Form/useRefineForm.ts
@@ -1,6 +1,7 @@
 import { Unstructured } from 'k8s-api-provider';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import usePathMap from 'src/hooks/usePathMap';
 import { getCommonErrors } from 'src/utils/error';
 import { transformResourceKindInSentence } from 'src/utils/string';
 import { ResourceConfig } from '../../types';
@@ -13,6 +14,11 @@ export const useRefineForm = (props: {
   useFormProps?: UseFormProps;
 }) => {
   const { config, id, refineProps } = props;
+  const { transformInitValues, transformApplyValues } = usePathMap({
+    pathMap: config.formConfig?.pathMap,
+    transformInitValues: config.formConfig?.transformInitValues,
+    transformApplyValues: config.formConfig?.transformApplyValues,
+  });
   const [responseErrorMsgs, setResponseErrorMsgs] = useState<string[]>([]);
   const { i18n } = useTranslation();
   const result = useForm({
@@ -43,8 +49,8 @@ export const useRefineForm = (props: {
       ...refineProps,
     },
     defaultValues: config?.initValue,
-    transformApplyValues: config.formConfig?.transformApplyValues,
-    transformInitValues: config.formConfig?.transformInitValues,
+    transformApplyValues,
+    transformInitValues,
     ...config.formConfig?.useFormProps,
   });
 

--- a/packages/refine/src/hooks/usePathMap.ts
+++ b/packages/refine/src/hooks/usePathMap.ts
@@ -1,0 +1,95 @@
+/**
+ * Utility hook for transforming data structures by mapping paths between different object structures.
+ * Useful for converting between form values and API data structures.
+ */
+
+import { Unstructured } from 'k8s-api-provider';
+import { get } from 'lodash-es';
+import { immutableSet } from '../utils/object';
+
+interface UsePathMapOptions {
+  /** Array of path mappings, each containing source path and target path arrays */
+  pathMap?: { from: string[]; to: string[] }[];
+  /** Optional function to transform initial values after path mapping */
+  transformInitValues?: (values: Record<string, unknown>) => Record<string, unknown>;
+  /** Optional function to transform values before applying/saving */
+  transformApplyValues?: (values: Record<string, unknown>) => Unstructured;
+}
+
+/**
+ * Hook that provides functions to transform data between different object structures using path mappings
+ * @param options Configuration options including path mappings and transform functions
+ * @returns Object containing transformation functions for init and apply operations
+ */
+function usePathMap(options: UsePathMapOptions): {
+  transformInitValues: (values: Record<string, unknown>) => Record<string, unknown>;
+  transformApplyValues: (values: Record<string, unknown>) => Unstructured;
+} {
+  const { pathMap, transformInitValues, transformApplyValues } = options;
+
+  return {
+    /**
+     * Transforms initial values by mapping paths from source to target structure
+     * @param values Initial values to transform
+     * @returns Transformed values with updated paths
+     */
+    transformInitValues(values: Record<string, unknown>) {
+      // Get raw YAML values or use values as is
+      const initValues = (values._rawYaml as Record<string, unknown> || values);
+      let result = initValues;
+
+      // Apply each path mapping
+      for (const { from, to } of (pathMap || [])) {
+        // Copy value from source path to target path
+        result = immutableSet(initValues, to, get(initValues, from));
+
+        // Clean up the source path after copying
+        const fromPath = [...from];
+        const lastKey = fromPath.pop();
+        if (lastKey) {
+          const obj = get(result, fromPath.join('.'));
+          if (obj && typeof obj === 'object') {
+            delete (obj as Record<string, unknown>)[lastKey];
+          }
+        }
+      }
+
+      // Apply custom transform if provided
+      return transformInitValues?.(result) || result;
+    },
+
+    /**
+     * Transforms values back to original structure before applying/saving
+     * @param values Values to transform back
+     * @returns Transformed values in original structure
+     */
+    transformApplyValues(values: Record<string, unknown>) {
+      let result = values;
+
+      // Apply each path mapping in reverse
+      for (const { from, to } of (pathMap || [])) {
+        // Copy value from target path back to source path
+        result = immutableSet(
+          values,
+          from,
+          get(result, to),
+        );
+
+        // Clean up the target path after copying back
+        const toPath = [...to];
+        const lastKey = toPath.pop();
+        if (lastKey) {
+          const obj = get(result, toPath.join('.'));
+          if (obj && typeof obj === 'object') {
+            delete (obj as Record<string, unknown>)[lastKey];
+          }
+        }
+      }
+
+      // Apply custom transform if provided
+      return transformApplyValues?.(result) || (result as Unstructured);
+    },
+  };
+}
+
+export default usePathMap;

--- a/packages/refine/src/types/resource.ts
+++ b/packages/refine/src/types/resource.ts
@@ -81,7 +81,7 @@ export type ResourceConfig<Model extends ResourceModel = ResourceModel> = {
   deleteTip?: string;
   /** 表单相关配置 */
   formConfig?: {
-    /** 
+    /**
      * 表单字段配置函数
      * @param props 包含记录和动作类型的配置对象
      * @returns 表单字段配置数组
@@ -93,34 +93,38 @@ export type ResourceConfig<Model extends ResourceModel = ResourceModel> = {
     }) => RefineFormField[];
     /** 保存按钮文本 */
     saveButtonText?: string;
-    /** 
+    /**
      * 自定义表单渲染函数
      * @param props YAML表单属性，待完善
      * @returns React节点
      */
     renderForm?: (props: YamlFormProps) => React.ReactNode;
-    /** 表单类型：页面形式或模态框形式 
+    /** 表单类型：页面形式或模态框形式
      * PAGE 或者 MODAL
     */
     formType?: FormType;
-    /** 
+    /**
      * 初始值转换函数
      * @param values 原始值
      * @returns 转换后的值
      */
     transformInitValues?: (values: Record<string, unknown>) => Record<string, unknown>;
-    /** 
+    /**
      * 提交值转换函数，转换为 YAML 格式
      * @param values 表单值
      * @returns YAML格式的数据
      */
     transformApplyValues?: (values: Record<string, unknown>) => Model['_rawYaml'];
-    /** 
+    /**
+     * 路径映射，用于在表单中映射路径
+     */
+    pathMap?: { from: string[]; to: string[] }[];
+    /**
      * 表单标题，可以是字符串或根据操作类型返回不同标题的函数
      * @param action 操作类型：create 或 edit
      */
     formTitle?: string | ((action: 'create' | 'edit') => string);
-    /** 
+    /**
      * 表单描述，可以是字符串或根据操作类型返回不同描述的函数
      * @param action 操作类型：create 或 edit
      */
@@ -129,7 +133,7 @@ export type ResourceConfig<Model extends ResourceModel = ResourceModel> = {
      * 默认是 216px
      */
     labelWidth?: string;
-    /** 
+    /**
      * 错误信息格式化函数，待完善
      * @param errorBody 错误信息体
      * @returns 格式化后的错误信息

--- a/packages/refine/src/utils/object.ts
+++ b/packages/refine/src/utils/object.ts
@@ -1,0 +1,7 @@
+import { setWith, clone } from 'lodash-es';
+
+export function immutableSet<
+  T extends Record<string, unknown> | unknown[] = Record<string, unknown>
+>(obj: T, path: string | string[], value: unknown): T {
+  return setWith(clone(obj), path, value, clone) as T;
+}


### PR DESCRIPTION
## 背景
当前 refine form 使用 react-hook-form 来实现的，它不支持在字段路径中传入带有 `.` 的字段，需要手动在初始化和提交表单时对字段进行转换来绕过这个限制。

https://github.com/react-hook-form/react-hook-form/issues/3351

## 解决方案
在表单中提供 `pathMap` 配置支持自动字段转换。

比如要配置 StorageClass 的 `parameters[csi.storage.k8s.io/fstype]` 字段，可以这样配置：

```
{
  pathMap: [
      [
        ['parameters', 'csi.storage.k8s.io/fstype'],
        ['parameters', 'fstype'],
      ]
  ],
  fields() {
    return [
        {
          path: ['parameters', 'fstype'],
          key: 'fstype',
          label: i18n.t('sks.fstype'),
          ...
        },
    ]
  }
}
```