### PR TITLE
refactor: update form handling and configuration structure

### DIFF
--- a/packages/refine/src/App.tsx
+++ b/packages/refine/src/App.tsx
@@ -3,11 +3,10 @@ import { GlobalStore } from 'k8s-api-provider';
 import React, { useMemo } from 'react';
 import { I18nextProvider } from 'react-i18next';
 import { Route, Router } from 'react-router-dom';
-import { YamlFormProps, Layout, YamlForm } from './components';
+import { Layout } from './components';
 import {
   CRONJOB_INIT_VALUE,
   DAEMONSET_INIT_VALUE,
-  DEPLOYMENT_INIT_VALUE,
   POD_INIT_VALUE,
   SERVER_INSTANCE_INIT_VALUE,
   NODE_INIT_VALUE,
@@ -30,17 +29,18 @@ import { ServicesConfig } from './pages/services';
 import { StatefulSetConfig } from './pages/statefulsets';
 import { StorageClassConfig } from './pages/storageclasses';
 import { ProviderPlugins } from './plugins';
-import { RESOURCE_GROUP, ResourceConfig, FormType } from './types';
+import { RESOURCE_GROUP, ResourceConfig, FormContainerType, FormType } from './types';
 
 function App() {
   const history = createBrowserHistory();
 
-  const resourcesConfig = useMemo(() => {
+  const resourcesConfig = useMemo((): ResourceConfig<any>[] => {
     return [
       {
         name: 'cronjobs',
         basePath: '/apis/batch/v1beta1',
         kind: 'CronJob',
+        apiVersion: 'batch/v1beta1',
         parent: RESOURCE_GROUP.WORKLOAD,
         initValue: CRONJOB_INIT_VALUE,
         isCustom: true,
@@ -49,6 +49,7 @@ function App() {
         name: 'daemonsets',
         basePath: '/apis/apps/v1',
         kind: 'DaemonSet',
+        apiVersion: 'apps/v1',
         parent: RESOURCE_GROUP.WORKLOAD,
         initValue: DAEMONSET_INIT_VALUE,
         isCustom: true,
@@ -57,16 +58,11 @@ function App() {
         name: 'deployments',
         basePath: '/apis/apps/v1',
         kind: 'Deployment',
+        apiVersion: 'apps/v1',
         parent: RESOURCE_GROUP.WORKLOAD,
         formConfig: {
-          formType: FormType.MODAL,
-          renderForm: (formProps: YamlFormProps) => (
-            <YamlForm
-              {...formProps}
-              initialValuesForCreate={DEPLOYMENT_INIT_VALUE}
-              isShowLayout={false}
-            />
-          ),
+          formType: FormType.YAML,
+          formContainerType: FormContainerType.MODAL,
         },
         isCustom: true,
       },
@@ -75,6 +71,7 @@ function App() {
         name: 'pods',
         basePath: '/api/v1',
         kind: 'Pod',
+        apiVersion: 'v1',
         parent: RESOURCE_GROUP.WORKLOAD,
         initValue: POD_INIT_VALUE,
         isCustom: true,
@@ -83,6 +80,7 @@ function App() {
         name: 'nodes',
         basePath: '/api/v1',
         kind: 'Node',
+        apiVersion: 'v1',
         parent: RESOURCE_GROUP.WORKLOAD,
         initValue: NODE_INIT_VALUE,
         isCustom: true,
@@ -94,10 +92,12 @@ function App() {
         name: 'serverinstances',
         basePath: '/apis/kubesmart.smtx.io/v1alpha1',
         kind: 'ServerInstance',
+        apiVersion: 'kubesmart.smtx.io/v1alpha1',
         parent: RESOURCE_GROUP.NETWORK,
         initValue: SERVER_INSTANCE_INIT_VALUE,
         noShow: true,
         formConfig: {
+          formType: FormType.FORM,
           useFormProps: {
             mode: 'onTouched',
           },
@@ -109,7 +109,7 @@ function App() {
               label: i18n.t('dovetail.name'),
               disabledWhenEdit: true,
               validators: [
-                (value: string) => {
+                (value: unknown) => {
                   if (!value)
                     return {
                       isValid: false,
@@ -169,7 +169,7 @@ function App() {
   return (
     <I18nextProvider i18n={i18n}>
       <Dovetail
-        resourcesConfig={resourcesConfig as ResourceConfig[]}
+        resourcesConfig={resourcesConfig}
         Layout={Layout}
         history={history}
         globalStore={globalStore}

--- a/packages/refine/src/components/Dropdowns/K8sDropdown/index.tsx
+++ b/packages/refine/src/components/Dropdowns/K8sDropdown/index.tsx
@@ -17,10 +17,10 @@ import { useDeleteModal } from 'src/hooks/useDeleteModal';
 import { useDownloadYAML } from 'src/hooks/useDownloadYAML';
 import { useFailedModal } from 'src/hooks/useFailedModal';
 import { useOpenForm } from 'src/hooks/useOpenForm';
+import { FormType } from 'src/types';
 import { getCommonErrors } from 'src/utils/error';
 import { useGlobalStore } from '../../../hooks';
 import { ResourceModel } from '../../../models';
-
 export type DropdownSize = 'normal' | 'large';
 
 interface K8sDropdownProps {
@@ -59,6 +59,7 @@ export function K8sDropdown(props: React.PropsWithChildren<K8sDropdownProps>) {
     resource: resource?.name,
     action: AccessControlAuth.Delete,
   });
+  const formType = config.formConfig?.formType || FormType.FORM;
 
   return (
     <>
@@ -67,7 +68,7 @@ export function K8sDropdown(props: React.PropsWithChildren<K8sDropdownProps>) {
           <Menu>
             {isInShowPage || canEditData?.can === false || config.hideEdit ? null : (
               <Menu.Item onClick={openForm}>
-                <Icon src={EditPen16PrimaryIcon}>{config.formConfig?.fields ? t('dovetail.edit') : t('dovetail.edit_yaml')}</Icon>
+                <Icon src={EditPen16PrimaryIcon}>{formType === FormType.FORM ? t('dovetail.edit') : t('dovetail.edit_yaml')}</Icon>
               </Menu.Item>
             )}
             <Menu.Item

--- a/packages/refine/src/components/Form/FormModal.tsx
+++ b/packages/refine/src/components/Form/FormModal.tsx
@@ -1,21 +1,20 @@
 import { CloseCircleFilled } from '@ant-design/icons';
-import { usePopModal, usePushModal, Modal, SegmentControl, Typo, Alert } from '@cloudtower/eagle';
+import { usePopModal, usePushModal, Modal, Typo } from '@cloudtower/eagle';
 import { ExclamationErrorCircleFill16RedIcon } from '@cloudtower/icons-react';
 import { css, cx } from '@linaria/core';
 import { useResource } from '@refinedev/core';
-import { Unstructured } from 'k8s-api-provider';
 import React, { useState, useContext, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import ConfigsContext from 'src/contexts/configs';
-import usePathMap from 'src/hooks/usePathMap';
 import { WarningButtonStyle } from 'src/styles/button';
 import { FullscreenModalStyle } from 'src/styles/modal';
 import { SmallModalStyle } from 'src/styles/modal';
+import { FormType, FormMode, RefineFormConfig, CommonFormConfig } from 'src/types';
 import { transformResourceKindInSentence } from 'src/utils/string';
-import { RefineFormContent } from './RefineFormContent';
-import useFieldsConfig from './useFieldsConfig';
-import { useRefineForm } from './useRefineForm';
-import { YamlForm, YamlFormProps } from './YamlForm';
+import FormModeSegmentControl from './FormModeSegmentControl';
+import RefineFormContainer from './RefineFormContainer';
+import { YamlFormProps } from './YamlForm';
+import YamlFormContainer from './YamlFormContainer';
 
 const FormDescStyle = css`
   margin-bottom: 16px;
@@ -34,6 +33,21 @@ const TitleWrapperStyle = css`
   justify-content: space-between;
   align-items: center;
 `;
+
+export type SaveButtonProps =
+  | {
+    disabled: boolean;
+    onClick: (e: React.BaseSyntheticEvent) => void;
+  }
+  | {
+    loading?:
+    | boolean
+    | {
+      delay?: number | undefined;
+    }
+    | undefined;
+    onClick?: (() => void) | undefined;
+  };
 
 export interface ConfirmModalProps {
   onOk?: () => void;
@@ -60,9 +74,7 @@ function ConfirmModal({ onOk }: ConfirmModalProps) {
       onCancel={popModal}
       destroyOnClose
     >
-      <div className={Typo.Label.l2_regular}>
-        {t('dovetail.exit_yaml_tip')}
-      </div>
+      <div className={Typo.Label.l2_regular}>{t('dovetail.exit_yaml_tip')}</div>
     </Modal>
   );
 }
@@ -70,122 +82,33 @@ function ConfirmModal({ onOk }: ConfirmModalProps) {
 export type FormModalProps = {
   resource?: string;
   id?: string;
-  formProps?: YamlFormProps;
-  renderForm?: (props: YamlFormProps) => React.ReactNode;
+  yamlFormProps?: YamlFormProps;
 };
 
-enum Mode {
-  Form = 'form',
-  Yaml = 'yaml'
-}
-
 export function FormModal(props: FormModalProps) {
-  const { resource: resourceFromProps, id, renderForm } = props;
+  const { resource: resourceFromProps, id, yamlFormProps: customYamlFormProps } = props;
   const { i18n } = useTranslation();
   const { resource } = useResource();
   const configs = useContext(ConfigsContext);
-  const [yamlSaveButtonProps, setYamlSaveButtonProps] = useState<{
-    loading?: boolean | { delay?: number | undefined };
-    onClick?: () => void;
-  }>({});
+  const [saveButtonProps, setSaveButtonProps] = useState<SaveButtonProps>({});
   const [isError, setIsError] = useState<boolean>(false);
-  const [mode, setMode] = useState<Mode>(Mode.Form);
-  const isYamlMode = mode === Mode.Yaml;
+  const [mode, setMode] = useState<FormMode>(FormMode.FORM);
+  const isYamlMode = mode === FormMode.YAML;
   const popModal = usePopModal();
   const pushModal = usePushModal();
   const config = configs[resourceFromProps || resource?.name || ''];
-  const isDisabledChangeMode = config.formConfig?.isDisabledChangeMode;
+  const isDisabledChangeMode =
+    config.formConfig &&
+    'isDisabledChangeMode' in config.formConfig &&
+    config.formConfig.isDisabledChangeMode;
   const okText = i18n.t(id ? 'dovetail.save' : 'dovetail.create');
   const action = id ? 'edit' : 'create';
-  const fieldsConfig = useFieldsConfig(config, id);
-  const refineFormResult = useRefineForm({
-    config,
-    id,
-    refineProps: {
-      onMutationSuccess: () => {
-        popModal();
-      },
-      redirect: false,
-      ...config.formConfig?.refineCoreProps,
-    },
-  });
-  const {
-    transformInitValues,
-    transformApplyValues,
-  } = usePathMap({
-    pathMap: config.formConfig?.pathMap,
-    transformInitValues: config.formConfig?.transformInitValues,
-    transformApplyValues: config.formConfig?.transformApplyValues || ((v: Record<string, unknown>) => v as Unstructured),
-  });
-  const yamlFormProps: YamlFormProps = useMemo(
-    () => {
-      return {
-        ...props.formProps,
-        transformInitValues: isYamlMode ? undefined : transformInitValues,
-        transformApplyValues: isYamlMode ? undefined : transformApplyValues,
-        initialValuesForCreate: isYamlMode ?
-          transformApplyValues(refineFormResult.formResult.getValues()) :
-          (props.formProps?.initialValuesForCreate || config?.initValue),
-        initialValuesForEdit: isYamlMode ?
-          transformApplyValues(refineFormResult.formResult.getValues()) : undefined,
-        id,
-        action,
-        isShowLayout: false,
-        useFormProps: {
-          redirect: false,
-        },
-        rules: isYamlMode ? fieldsConfig?.map((config) => ({
-          path: config.path,
-          validators: config.validators,
-        })) : undefined,
-        onSaveButtonPropsChange: setYamlSaveButtonProps,
-        onErrorsChange(errors) {
-          setIsError(!!errors.length);
-        },
-        onFinish: popModal,
-      };
-    },
-    [
-      props.formProps,
-      config?.initValue,
-      id,
-      action,
-      refineFormResult.formResult,
-      isYamlMode,
-      fieldsConfig,
-      popModal,
-      transformInitValues,
-      transformApplyValues,
-    ]
-  );
 
-  const isYamlForm = !config.formConfig?.fields;
-
-  const formEle = (() => {
-    if (renderForm) {
-      return renderForm(yamlFormProps);
-    }
-
-    if (isYamlForm || isYamlMode) return <YamlForm {...yamlFormProps} />;
-
-    return (
-      <RefineFormContent
-        formResult={refineFormResult.formResult}
-        config={config}
-        errorMsgs={refineFormResult.responseErrorMsgs}
-        resourceId={id as string}
-      />
-    );
-  })();
-
-  const saveButtonProps = isYamlForm || isYamlMode
-    ? yamlSaveButtonProps
-    : refineFormResult.formResult.saveButtonProps;
+  const isYamlForm = config.formConfig?.formType === FormType.YAML;
 
   const onCancel = useCallback(() => {
     popModal();
   }, [popModal]);
-
   const onOk = useCallback(
     e => {
       setIsError(false);
@@ -193,27 +116,30 @@ export function FormModal(props: FormModalProps) {
     },
     [saveButtonProps]
   );
-  const onChangeMode = useCallback((value: Mode) => {
-    if (value === Mode.Form) {
-      pushModal<'ConfirmModal'>({
-        component: ConfirmModal,
-        props: {
-          onOk: () => {
-            setMode(Mode.Form);
+  const onChangeMode = useCallback(
+    (value: FormMode) => {
+      if (value === FormMode.FORM) {
+        pushModal<'ConfirmModal'>({
+          component: ConfirmModal,
+          props: {
+            onOk: () => {
+              setMode(FormMode.FORM);
+            },
           },
-        },
-      });
-    } else {
-      setMode(value);
-    }
-  }, [pushModal]);
+        });
+      } else {
+        setMode(value);
+      }
+    },
+    [pushModal]
+  );
 
-  const errorText = (() => {
-    if (!!refineFormResult.responseErrorMsgs.length || isError) {
+  const errorText = useMemo(() => {
+    if (isError) {
       return i18n.t(id ? 'dovetail.save_failed' : 'dovetail.create_failed');
     }
-  })();
-
+    return '';
+  }, [isError, id, i18n]);
   const title = useMemo(() => {
     if (typeof config.formConfig?.formTitle === 'string')
       return config.formConfig?.formTitle;
@@ -227,7 +153,6 @@ export function FormModal(props: FormModalProps) {
       resource: transformResourceKindInSentence(label, i18n.language),
     });
   }, [action, config.formConfig, config.displayName, config?.kind, i18n, id]);
-
   const desc = useMemo(() => {
     if (typeof config.formConfig?.formDesc === 'string')
       return config.formConfig?.formDesc;
@@ -237,37 +162,58 @@ export function FormModal(props: FormModalProps) {
     }
     return '';
   }, [action, config.formConfig]);
+  const formEle = useMemo(() => {
+    const commonFormProps = {
+      id: id as string,
+      config,
+      customYamlFormProps,
+      onSaveButtonPropsChange: setSaveButtonProps,
+      onError: () => {
+        setIsError(true);
+      },
+      onSuccess: () => {
+        setIsError(false);
+        popModal();
+      },
+    };
+
+    if (
+      config.formConfig &&
+      (config.formConfig?.formType === FormType.FORM || 'fields' in config.formConfig)
+    ) {
+      return (
+        <RefineFormContainer
+          {...commonFormProps}
+          isYamlMode={isYamlMode}
+          formConfig={config.formConfig as RefineFormConfig & CommonFormConfig}
+        />
+      );
+    }
+
+    return <YamlFormContainer {...commonFormProps} formConfig={config.formConfig} />;
+  }, [id, customYamlFormProps, config, isYamlMode, popModal, setSaveButtonProps]);
 
   return (
     <Modal
-      className={cx(
-        FullscreenModalStyle,
-      )}
-      style={{ '--max-modal-width': isYamlForm || !isDisabledChangeMode ? '1024px' : '648px' } as React.CSSProperties}
+      className={cx(FullscreenModalStyle)}
+      style={
+        {
+          '--max-modal-width': isYamlForm || !isDisabledChangeMode ? '1024px' : '648px',
+        } as React.CSSProperties
+      }
       width="calc(100vw - 16px)"
-      title={(
+      title={
         <div className={TitleWrapperStyle}>
           <span>{title}</span>
-          {
-            !(isYamlForm || isDisabledChangeMode) ? (
-              <SegmentControl
-                style={{ fontWeight: 'normal' }}
-                value={mode}
-                options={[{
-                  value: Mode.Form,
-                  label: i18n.t('dovetail.form')
-                }, {
-                  value: Mode.Yaml,
-                  label: i18n.t('dovetail.yaml')
-                }]}
-                onChange={(val) => {
-                  onChangeMode(val as Mode);
-                }}
-              />
-            ) : null
-          }
+          {config.formConfig?.formType === FormType.FORM ? (
+            <FormModeSegmentControl
+              formConfig={config.formConfig}
+              mode={mode}
+              onChangeMode={onChangeMode}
+            />
+          ) : null}
         </div>
-      )}
+      }
       error={
         errorText ? (
           <div className={ErrorStyle}>
@@ -289,13 +235,6 @@ export function FormModal(props: FormModalProps) {
       fullscreen
     >
       {desc ? <div className={FormDescStyle}>{desc}</div> : undefined}
-      {!isYamlForm && mode === Mode.Form && !isDisabledChangeMode ?
-        (<Alert
-          type="warning"
-          message={i18n.t('dovetail.change_form_mode_alert')}
-          style={{ marginBottom: '16px' }}
-        />) :
-        undefined}
       {formEle}
     </Modal>
   );

--- a/packages/refine/src/components/Form/FormModeSegmentControl.tsx
+++ b/packages/refine/src/components/Form/FormModeSegmentControl.tsx
@@ -1,0 +1,40 @@
+import { SegmentControl } from '@cloudtower/eagle';
+import React from 'react';
+import i18n from 'src/i18n';
+import { CommonFormConfig, RefineFormConfig, FormMode } from 'src/types';
+
+interface FormModeSegmentControlProps {
+  formConfig: CommonFormConfig & RefineFormConfig;
+  mode: FormMode;
+  onChangeMode: (mode: FormMode) => void;
+}
+
+function FormModeSegmentControl({
+  formConfig,
+  mode,
+  onChangeMode,
+}: FormModeSegmentControlProps) {
+  const { isDisabledChangeMode } = formConfig;
+
+  return !isDisabledChangeMode ? (
+    <SegmentControl
+      style={{ fontWeight: 'normal' }}
+      value={mode}
+      options={[
+        {
+          value: FormMode.FORM,
+          label: i18n.t('dovetail.form'),
+        },
+        {
+          value: FormMode.YAML,
+          label: i18n.t('dovetail.yaml'),
+        },
+      ]}
+      onChange={val => {
+        onChangeMode(val as FormMode);
+      }}
+    />
+  ) : null;
+}
+
+export default FormModeSegmentControl;

--- a/packages/refine/src/components/Form/RefineFormContainer.tsx
+++ b/packages/refine/src/components/Form/RefineFormContainer.tsx
@@ -1,0 +1,130 @@
+import { Alert } from '@cloudtower/eagle';
+import { Unstructured } from 'k8s-api-provider';
+import React, { useMemo, useEffect } from 'react';
+import { type SaveButtonProps } from 'src/components/Form/FormModal';
+import i18n from 'src/i18n';
+import { ResourceConfig } from 'src/types';
+import { CommonFormConfig, RefineFormConfig } from 'src/types';
+import { RefineFormContent } from './RefineFormContent';
+import useFieldsConfig from './useFieldsConfig';
+import { useRefineForm } from './useRefineForm';
+import { YamlForm, YamlFormProps } from './YamlForm';
+
+interface RefineFormContainerProps {
+  id: string;
+  isYamlMode: boolean;
+  config: ResourceConfig;
+  formConfig: (RefineFormConfig & CommonFormConfig) | undefined;
+  customYamlFormProps?: YamlFormProps;
+  onSaveButtonPropsChange?: (props: SaveButtonProps) => void;
+  onError?: () => void;
+  onSuccess?: () => void;
+}
+
+function RefineFormContainer({
+  id,
+  config,
+  customYamlFormProps,
+  formConfig,
+  isYamlMode,
+  onSuccess,
+  onError,
+  onSaveButtonPropsChange,
+}: RefineFormContainerProps) {
+  const action = id ? 'edit' : 'create';
+  const fieldsConfig = useFieldsConfig(config, formConfig, id);
+  const refineFormResult = useRefineForm({
+    config,
+    id,
+    refineProps: {
+      onMutationSuccess: () => {
+        onSuccess?.();
+      },
+      onMutationError() {
+        onError?.();
+      },
+      redirect: false,
+      ...formConfig?.refineCoreProps,
+    },
+  });
+  const yamlFormProps: YamlFormProps = useMemo(() => {
+    const transformApplyValues =
+      formConfig?.transformApplyValues ||
+      ((v: Record<string, unknown>) => v as Unstructured);
+
+    return {
+      ...customYamlFormProps,
+      config,
+      transformInitValues: undefined,
+      transformApplyValues: undefined,
+      initialValuesForCreate: transformApplyValues(
+        refineFormResult.formResult.getValues()
+      ),
+      initialValuesForEdit: transformApplyValues(refineFormResult.formResult.getValues()),
+      id,
+      action,
+      isShowLayout: false,
+      useFormProps: {
+        redirect: false,
+      },
+      rules: fieldsConfig?.map(config => ({
+        path: config.path,
+        validators: config.validators,
+      })),
+      onSaveButtonPropsChange,
+      onErrorsChange(errors: string[]) {
+        if (errors.length) {
+          onError?.();
+        }
+      },
+      onFinish: onSuccess,
+    };
+  }, [
+    action,
+    customYamlFormProps,
+    fieldsConfig,
+    config,
+    id,
+    refineFormResult,
+    formConfig,
+    onSaveButtonPropsChange,
+    onSuccess,
+    onError,
+  ]);
+
+  useEffect(() => {
+    if (!isYamlMode) {
+      onSaveButtonPropsChange?.(refineFormResult.formResult.saveButtonProps);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isYamlMode, onSaveButtonPropsChange]);
+
+  if (isYamlMode) {
+    return <YamlForm {...yamlFormProps} />;
+  }
+
+  return (
+    <>
+      {!formConfig?.isDisabledChangeMode ? (
+        <Alert
+          type="warning"
+          message={i18n.t('dovetail.change_form_mode_alert')}
+          style={{ marginBottom: '16px' }}
+        />
+      ) : undefined}
+      {formConfig?.renderForm ? (
+        formConfig?.renderForm()
+      ) : (
+        <RefineFormContent
+          formResult={refineFormResult.formResult}
+          config={config}
+          formConfig={formConfig}
+          errorMsgs={refineFormResult.responseErrorMsgs}
+          resourceId={id as string}
+        />
+      )}
+    </>
+  );
+}
+
+export default RefineFormContainer;

--- a/packages/refine/src/components/Form/RefineFormContent.tsx
+++ b/packages/refine/src/components/Form/RefineFormContent.tsx
@@ -4,23 +4,24 @@ import { UseFormReturnType } from '@refinedev/react-hook-form';
 import React from 'react';
 import { Controller } from 'react-hook-form';
 import { ResourceModel } from 'src/models';
-import { ResourceConfig } from 'src/types';
+import { CommonFormConfig, FormType, RefineFormConfig, ResourceConfig } from 'src/types';
 import { FormErrorAlert } from '../FormErrorAlert';
 import useFieldsConfig from './useFieldsConfig';
 
 type Props<Model extends ResourceModel> = {
   config?: ResourceConfig<Model>;
+  formConfig?: CommonFormConfig & RefineFormConfig;
   formResult: UseFormReturnType;
   errorMsgs?: string[];
   resourceId?: string;
 };
 
 export const RefineFormContent = <Model extends ResourceModel>(props: Props<Model>) => {
-  const { config, formResult, resourceId, errorMsgs } = props;
+  const { config, formResult, resourceId, errorMsgs, formConfig } = props;
   const { control, getValues } = formResult;
   const action = resourceId ? 'edit' : 'create';
 
-  const formFieldsConfig = useFieldsConfig(config, resourceId);
+  const formFieldsConfig = useFieldsConfig(config, formConfig, resourceId);
 
   const fields = formFieldsConfig?.map(c => {
     return (
@@ -33,7 +34,7 @@ export const RefineFormContent = <Model extends ResourceModel>(props: Props<Mode
             const formValue = getValues();
             if (!c.validators || c.validators.length === 0) return true;
             for (const func of c.validators) {
-              const { isValid, errorMsg } = func(value, formValue, 'form');
+              const { isValid, errorMsg } = func(value, formValue, FormType.FORM);
               if (!isValid) return errorMsg;
             }
             return true;
@@ -66,7 +67,6 @@ export const RefineFormContent = <Model extends ResourceModel>(props: Props<Mode
           if (action === 'edit' && c.disabledWhenEdit) {
             ele = <div>{value}</div>;
           }
-
 
           if (c?.render) {
             ele = c.render(value, onChange, formValue, onBlur, action, control);
@@ -102,7 +102,7 @@ export const RefineFormContent = <Model extends ResourceModel>(props: Props<Mode
               key={c.key}
               label={c.label}
               colon={false}
-              labelCol={{ flex: `0 0 ${config?.formConfig?.labelWidth || '216px'}` }}
+              labelCol={{ flex: `0 0 ${formConfig?.labelWidth || '216px'}` }}
               help={fieldState.error?.message}
               validateStatus={fieldState.invalid ? 'error' : undefined}
               data-test-id={c.key}

--- a/packages/refine/src/components/Form/YamlForm.tsx
+++ b/packages/refine/src/components/Form/YamlForm.tsx
@@ -2,14 +2,15 @@ import { Form, Loading } from '@cloudtower/eagle';
 import { css } from '@linaria/core';
 import { FormAction, useResource } from '@refinedev/core';
 import { Unstructured } from 'k8s-api-provider';
-import React, { useMemo, useCallback, useEffect, useContext } from 'react';
+import React, { useMemo, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import ErrorContent from 'src/components/ErrorContent';
 import { FormErrorAlert } from 'src/components/FormErrorAlert';
 import FormLayout from 'src/components/FormLayout';
 import { YamlEditorComponent } from 'src/components/YamlEditor/YamlEditorComponent';
 import { BASE_INIT_VALUE } from 'src/constants/k8s';
-import ConfigsContext from 'src/contexts/configs';
+import { ResourceModel } from 'src/models';
+import { ResourceConfig } from 'src/types';
 import { getCommonErrors } from 'src/utils/error';
 import { transformResourceKindInSentence } from 'src/utils/string';
 import useYamlForm from './useYamlForm';
@@ -28,9 +29,10 @@ export enum SchemaStrategy {
   None = 'None',
 }
 
-export interface YamlFormProps {
+export interface YamlFormProps<Model extends ResourceModel = ResourceModel> {
   id?: string;
   action?: FormAction;
+  config: ResourceConfig<Model>;
   initialValuesForCreate?: Record<string, unknown>;
   initialValuesForEdit?: Record<string, unknown>;
   schemaStrategy?: SchemaStrategy;
@@ -48,13 +50,14 @@ export interface YamlFormProps {
   onFinish?: () => void;
 }
 
-export function YamlForm(props: YamlFormProps) {
+export function YamlForm<Model extends ResourceModel = ResourceModel>(props: YamlFormProps<Model>) {
   const {
     id,
     action: actionFromProps,
     schemaStrategy = SchemaStrategy.Optional,
     isShowLayout = true,
     useFormProps,
+    config,
     transformInitValues,
     transformApplyValues,
     onSaveButtonPropsChange,
@@ -63,8 +66,6 @@ export function YamlForm(props: YamlFormProps) {
   } = props;
   const { action: actionFromResource, resource } = useResource();
   const action = actionFromProps || actionFromResource;
-  const configs = useContext(ConfigsContext);
-  const config = configs[resource?.name || ''];
   const { t, i18n } = useTranslation();
   const {
     formProps,

--- a/packages/refine/src/components/Form/YamlFormContainer.tsx
+++ b/packages/refine/src/components/Form/YamlFormContainer.tsx
@@ -1,0 +1,81 @@
+import { Unstructured } from 'k8s-api-provider';
+import React, { useMemo } from 'react';
+import { type SaveButtonProps } from 'src/components/Form/FormModal';
+import usePathMap from 'src/hooks/usePathMap';
+import { ResourceConfig } from 'src/types';
+import { CommonFormConfig } from 'src/types';
+import { YamlFormConfig } from 'src/types';
+import { YamlForm, YamlFormProps } from './YamlForm';
+
+interface YamlFormContainerProps {
+  id: string;
+  config: ResourceConfig;
+  customYamlFormProps?: YamlFormProps;
+  formConfig?: YamlFormConfig & CommonFormConfig;
+  onSuccess?: () => void;
+  onError?: () => void;
+  onSaveButtonPropsChange?: (props: SaveButtonProps) => void;
+}
+
+function YamlFormContainer({
+  id,
+  customYamlFormProps,
+  config,
+  formConfig,
+  onSuccess,
+  onError,
+  onSaveButtonPropsChange
+}: YamlFormContainerProps) {
+  const action = id ? 'edit' : 'create';
+  const {
+    transformInitValues,
+    transformApplyValues,
+  } = usePathMap({
+    pathMap: formConfig?.pathMap,
+    transformInitValues: formConfig?.transformInitValues,
+    transformApplyValues: formConfig?.transformApplyValues || ((v: Record<string, unknown>) => v as Unstructured),
+  });
+  const yamlFormProps: YamlFormProps = useMemo(
+    () => {
+      return {
+        ...customYamlFormProps,
+        config,
+        transformInitValues,
+        transformApplyValues,
+        initialValuesForCreate: (customYamlFormProps?.initialValuesForCreate || config.initValue),
+        initialValuesForEdit: undefined,
+        id,
+        action,
+        isShowLayout: false,
+        useFormProps: {
+          redirect: false,
+        },
+        rules: undefined,
+        onSaveButtonPropsChange,
+        onErrorsChange(errors: string[]) {
+          if (errors.length) {
+            onError?.();
+          }
+        },
+        onFinish: onSuccess,
+      };
+    },
+    [
+      id,
+      action,
+      customYamlFormProps,
+      config,
+      transformInitValues,
+      transformApplyValues,
+      onSuccess,
+      onError,
+      onSaveButtonPropsChange,
+    ]
+  );
+
+  return (
+    <YamlForm {...yamlFormProps} />
+  );
+}
+
+export default YamlFormContainer;

--- a/packages/refine/src/components/Form/type.ts
+++ b/packages/refine/src/components/Form/type.ts
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Control } from 'react-hook-form';
+import { FormType } from 'src/types/resource';
 
 export type RefineFormValidator = (
   value: unknown,
   formValue: unknown,
-  formMode: 'yaml' | 'form'
+  formMode: FormType
 ) => { isValid: boolean; errorMsg: string };
 
 export type RefineFormField = {

--- a/packages/refine/src/components/Form/useFieldsConfig.ts
+++ b/packages/refine/src/components/Form/useFieldsConfig.ts
@@ -1,8 +1,8 @@
 import { useList, useShow } from '@refinedev/core';
 import { ResourceModel } from 'src/models';
-import { ResourceConfig } from 'src/types';
+import { CommonFormConfig, RefineFormConfig, ResourceConfig } from 'src/types';
 
-function useFieldsConfig<Model extends ResourceModel>(config?: ResourceConfig<Model>, resourceId?: string) {
+function useFieldsConfig<Model extends ResourceModel>(config?: ResourceConfig<Model>, formConfig?: CommonFormConfig & RefineFormConfig, resourceId?: string) {
   const action = resourceId ? 'edit' : 'create';
   const listQuery = useList<Model>({
     resource: config?.name,
@@ -17,7 +17,7 @@ function useFieldsConfig<Model extends ResourceModel>(config?: ResourceConfig<Mo
     id: resourceId,
   });
 
-  return config?.formConfig?.fields?.({
+  return formConfig?.fields?.({
     record: showQuery.queryResult.data?.data,
     records: listQuery.data?.data || [],
     action,

--- a/packages/refine/src/components/Form/useRefineForm.ts
+++ b/packages/refine/src/components/Form/useRefineForm.ts
@@ -4,20 +4,21 @@ import { useTranslation } from 'react-i18next';
 import usePathMap from 'src/hooks/usePathMap';
 import { getCommonErrors } from 'src/utils/error';
 import { transformResourceKindInSentence } from 'src/utils/string';
-import { ResourceConfig } from '../../types';
+import { CommonFormConfig, ErrorBody, RefineFormConfig, ResourceConfig } from '../../types';
 import { useForm, UseFormProps } from './useReactHookForm';
 
 export const useRefineForm = (props: {
-  config: ResourceConfig;
+  formConfig?: RefineFormConfig & CommonFormConfig;
   id?: string;
+  config: ResourceConfig;
   refineProps?: UseFormProps['refineCoreProps'];
   useFormProps?: UseFormProps;
 }) => {
-  const { config, id, refineProps } = props;
+  const { formConfig, config, id, refineProps } = props;
   const { transformInitValues, transformApplyValues } = usePathMap({
-    pathMap: config.formConfig?.pathMap,
-    transformInitValues: config.formConfig?.transformInitValues,
-    transformApplyValues: config.formConfig?.transformApplyValues,
+    pathMap: formConfig?.pathMap,
+    transformInitValues: formConfig?.transformInitValues,
+    transformApplyValues: formConfig?.transformApplyValues,
   });
   const [responseErrorMsgs, setResponseErrorMsgs] = useState<string[]>([]);
   const { i18n } = useTranslation();
@@ -51,18 +52,18 @@ export const useRefineForm = (props: {
     defaultValues: config?.initValue,
     transformApplyValues,
     transformInitValues,
-    ...config.formConfig?.useFormProps,
+    ...formConfig?.useFormProps,
   });
 
   // set request error message
   useEffect(() => {
     const response = result.refineCore.mutationResult.error?.response;
     if (response && !response?.bodyUsed) {
-      response.json?.().then((body: any) => {
-        setResponseErrorMsgs(([] as string[]).concat(config.formConfig?.formatError?.(body) || getCommonErrors(body, i18n)));
+      response.json?.().then((body: ErrorBody) => {
+        setResponseErrorMsgs(([] as string[]).concat(formConfig?.formatError?.(body) || getCommonErrors(body, i18n)));
       });
     }
-  }, [config.formConfig, result, i18n]);
+  }, [formConfig, result, i18n]);
 
   return { formResult: result, responseErrorMsgs };
 };

--- a/packages/refine/src/components/Form/useYamlForm.ts
+++ b/packages/refine/src/components/Form/useYamlForm.ts
@@ -23,6 +23,7 @@ import { RefineFormValidator } from 'src/components/Form/type';
 import { type YamlEditorHandle, type YamlEditorProps } from 'src/components/YamlEditor';
 import useK8sYamlEditor from 'src/hooks/useK8sYamlEditor';
 import { useSchema } from 'src/hooks/useSchema';
+import { FormType } from 'src/types/resource';
 import { pruneBeforeEdit } from 'src/utils/k8s';
 import { generateYamlBySchema } from 'src/utils/yaml';
 import { useForm as useFormSF } from 'sunflower-antd';
@@ -283,7 +284,7 @@ const useYamlForm = <
         const value = get(formValue, path);
 
         for (const validator of (validators || [])) {
-          const { isValid, errorMsg } = validator(value, formValue, 'yaml');
+          const { isValid, errorMsg } = validator(value, formValue, FormType.YAML);
 
           if (!isValid) {
             errorMap[path.join('.')] = `${errorMsg}(${path.join('.')})`;

--- a/packages/refine/src/components/InternalBaseTable/index.tsx
+++ b/packages/refine/src/components/InternalBaseTable/index.tsx
@@ -3,7 +3,7 @@ import { css, cx } from '@linaria/core';
 import React, { useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import ErrorContent from 'src/components/ErrorContent';
-import { FormType } from 'src/types';
+import { FormContainerType } from 'src/types';
 import { AuxiliaryLine } from './TableWidgets';
 
 export type IDObject = { id: string };
@@ -47,7 +47,7 @@ export type InternalTableProps<Data extends { id: string; }> = {
   onPageChange: (page: number) => void;
   onSizeChange?: (size: number) => void;
   onSorterChange?: (order: SorterOrder | null, key?: string) => void;
-  RowMenu?: React.FC<{ record: Data; formType?: FormType; }>;
+  RowMenu?: React.FC<{ record: Data; formType?: FormContainerType; }>;
   empty?: string;
   showMenuColumn?: boolean;
   hideNamespacesFilter?: boolean;

--- a/packages/refine/src/components/ResourceCRUD/ResourceCRUD.tsx
+++ b/packages/refine/src/components/ResourceCRUD/ResourceCRUD.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { ResourceConfig, FormType } from '../../types';
+import { ResourceConfig, FormContainerType } from '../../types';
 import { ResourceForm } from './create';
 import { ResourceList } from './list';
 import { ResourceShow } from './show';
@@ -25,7 +25,7 @@ export function ResourceCRUD(props: Props) {
             ) : null}
             {
               // the modals would render in ModalStack
-              config.formConfig?.formType === FormType.PAGE ? (
+              config.formConfig?.formContainerType === FormContainerType.PAGE ? (
                 <>
                   <Route path={`${urlPrefix}/${config.name}/create`}>
                     <ResourceForm config={config} />

--- a/packages/refine/src/components/ResourceCRUD/create/index.tsx
+++ b/packages/refine/src/components/ResourceCRUD/create/index.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { YamlForm, YamlFormProps } from 'src/components';
 import { getInitialValues } from 'src/utils/form';
 import { ResourceModel } from '../../../models';
-import { ResourceConfig } from '../../../types';
+import { FormType, ResourceConfig } from '../../../types';
 import { RefineFormPage } from '../../Form';
 
 type Props<Model extends ResourceModel> = {
@@ -11,17 +11,18 @@ type Props<Model extends ResourceModel> = {
 
 export function ResourceForm<Model extends ResourceModel>(props: Props<Model>) {
   const { config } = props;
-  const formProps: YamlFormProps = useMemo(() => {
+  const formProps: YamlFormProps<Model> = useMemo(() => {
     return {
       initialValues: getInitialValues(config),
       transformInitValues: config.formConfig?.transformInitValues,
       transformApplyValues: config.formConfig?.transformApplyValues,
+      config,
     };
   }, [config]);
 
-  if (config.formConfig?.fields) {
+  if (config.formConfig?.formType === FormType.FORM) {
     return <RefineFormPage config={config} />;
   }
 
-  return <YamlForm {...formProps} />;
+  return <YamlForm<Model> {...formProps} />;
 }

--- a/packages/refine/src/components/ShowContent/ShowContent.tsx
+++ b/packages/refine/src/components/ShowContent/ShowContent.tsx
@@ -31,11 +31,11 @@ import { AccessControlAuth } from 'src/constants/auth';
 import ComponentContext from 'src/contexts/component';
 import ConfigsContext from 'src/contexts/configs';
 import { useOpenForm } from 'src/hooks/useOpenForm';
+import { FormType } from 'src/types';
 import { ResourceState } from '../../constants';
 import { ResourceModel } from '../../models';
 import { StateTag } from '../StateTag';
 import { ShowConfig, ShowField, AreaType } from './fields';
-
 const ShowContentWrapperStyle = css`
   height: 100%;
   display: flex;
@@ -292,7 +292,7 @@ export const ShowContent = <Model extends ResourceModel>(props: Props<Model>) =>
           {!config.hideEdit ? (
             <CanAccess resource={resource?.name} action={AccessControlAuth.Edit}>
               <Button style={{ marginRight: 8 }} onClick={openForm}>
-                {config.formConfig?.fields ? t('dovetail.edit') : t('dovetail.edit_yaml')}
+                {config.formConfig?.formType === FormType.FORM ? t('dovetail.edit') : t('dovetail.edit_yaml')}
               </Button>
             </CanAccess>
           ) : null}

--- a/packages/refine/src/hooks/useOpenForm.ts
+++ b/packages/refine/src/hooks/useOpenForm.ts
@@ -3,13 +3,12 @@ import { useResource, useGo, useNavigation } from '@refinedev/core';
 import { useContext } from 'react';
 import ConfigsContext from 'src/contexts/configs';
 import { useEdit } from 'src/hooks/useEdit';
-import { FormType } from 'src/types';
+import { FormContainerType } from 'src/types';
 import { getInitialValues } from 'src/utils/form';
-import { FormModal, YamlFormProps } from '../components';
+import { FormModal } from '../components';
 
 interface UseOpenFormOptions {
   id?: string;
-  renderForm?: (props: YamlFormProps) => React.ReactNode;
 }
 
 export function useOpenForm(options?: UseOpenFormOptions) {
@@ -23,9 +22,9 @@ export function useOpenForm(options?: UseOpenFormOptions) {
   return function openForm() {
     if (resource?.name) {
       const config = configs[resource.name];
-      const formType = config.formConfig?.formType;
+      const formType = config.formConfig?.formContainerType;
 
-      if (formType === undefined || formType === FormType.MODAL) {
+      if (formType === undefined || formType === FormContainerType.MODAL) {
         pushModal<'FormModal'>({
           component: config.formConfig?.CustomFormModal || FormModal,
           props: {
@@ -34,7 +33,6 @@ export function useOpenForm(options?: UseOpenFormOptions) {
             formProps: {
               initialValues: getInitialValues(config),
             },
-            renderForm: options?.renderForm || config.formConfig?.renderForm,
           },
         });
       } else if (options?.id) {

--- a/packages/refine/src/pages/cronjobs/create/index.tsx
+++ b/packages/refine/src/pages/cronjobs/create/index.tsx
@@ -1,8 +1,12 @@
 import { FormProps } from 'antd/lib/form';
-import React from 'react';
+import React, { useContext } from 'react';
 import { YamlForm } from 'src/components';
 import { CRONJOB_INIT_VALUE } from 'src/constants/k8s';
+import ConfigsContext from 'src/contexts/configs';
 
 export const CronJobForm: React.FC<FormProps> = () => {
-  return <YamlForm initialValuesForCreate={CRONJOB_INIT_VALUE} />;
+  const configs = useContext(ConfigsContext);
+  const config = configs['cronjobs'];
+
+  return <YamlForm initialValuesForCreate={CRONJOB_INIT_VALUE} config={config} />;
 };

--- a/packages/refine/src/pages/daemonsets/create/index.tsx
+++ b/packages/refine/src/pages/daemonsets/create/index.tsx
@@ -1,8 +1,12 @@
 import { FormProps } from 'antd/lib/form';
-import React from 'react';
+import React, { useContext } from 'react';
 import { YamlForm } from 'src/components';
 import { DAEMONSET_INIT_VALUE } from 'src/constants/k8s';
+import ConfigsContext from 'src/contexts/configs';
 
 export const DaemonSetForm: React.FC<FormProps> = () => {
-  return <YamlForm initialValuesForCreate={DAEMONSET_INIT_VALUE} />;
+  const configs = useContext(ConfigsContext);
+  const config = configs['daemonsets'];
+
+  return <YamlForm initialValuesForCreate={DAEMONSET_INIT_VALUE} config={config} />;
 };

--- a/packages/refine/src/pages/ingresses/index.tsx
+++ b/packages/refine/src/pages/ingresses/index.tsx
@@ -13,7 +13,7 @@ import {
   IngressRulesColumnRenderer,
 } from '../../hooks/useEagleTable/columns';
 import { IngressModel } from '../../models';
-import { RESOURCE_GROUP, ResourceConfig, FormType } from '../../types';
+import { RESOURCE_GROUP, ResourceConfig, FormContainerType, FormType } from '../../types';
 
 export const IngressConfig = (i18n: i18n): ResourceConfig<IngressModel> => ({
   name: 'ingresses',
@@ -40,6 +40,7 @@ export const IngressConfig = (i18n: i18n): ResourceConfig<IngressModel> => ({
   initValue: INGRESS_INIT_VALUE,
   Dropdown: K8sDropdown,
   formConfig: {
-    formType: FormType.MODAL,
+    formType: FormType.FORM,
+    formContainerType: FormContainerType.MODAL,
   }
 });

--- a/packages/refine/src/pages/jobs/index.ts
+++ b/packages/refine/src/pages/jobs/index.ts
@@ -1,5 +1,5 @@
 import { i18n } from 'i18next';
-import { FormType } from 'src/types';
+import { FormContainerType } from 'src/types';
 import { Column } from '../../components';
 import K8sDropdown from '../../components/Dropdowns/K8sDropdown';
 import {
@@ -20,7 +20,7 @@ import {
   WorkloadRestartsColumnRenderer,
 } from '../../hooks/useEagleTable/columns';
 import { JobModel } from '../../models';
-import { RESOURCE_GROUP, ResourceConfig } from '../../types';
+import { RESOURCE_GROUP, ResourceConfig, FormType } from '../../types';
 
 export const JobConfig = (i18n: i18n): ResourceConfig<JobModel> => ({
   name: 'jobs',
@@ -59,6 +59,7 @@ export const JobConfig = (i18n: i18n): ResourceConfig<JobModel> => ({
   initValue: JOB_INIT_VALUE,
   Dropdown: K8sDropdown,
   formConfig: {
-    formType: FormType.MODAL,
+    formType: FormType.FORM,
+    formContainerType: FormContainerType.MODAL,
   }
 });

--- a/packages/refine/src/pages/networkPolicies/index.tsx
+++ b/packages/refine/src/pages/networkPolicies/index.tsx
@@ -12,7 +12,7 @@ import K8sDropdown from '../../components/Dropdowns/K8sDropdown';
 import { NETWORK_POLICY_INIT_VALUE } from '../../constants/k8s';
 import { AgeColumnRenderer } from '../../hooks/useEagleTable/columns';
 import { NetworkPolicyModel } from '../../models';
-import { RESOURCE_GROUP, ResourceConfig, FormType } from '../../types';
+import { RESOURCE_GROUP, ResourceConfig, FormContainerType, FormType } from '../../types';
 
 export const NetworkPolicyConfig = (i18n: i18n): ResourceConfig<NetworkPolicyModel> => ({
   name: 'networkpolicies',
@@ -61,6 +61,7 @@ export const NetworkPolicyConfig = (i18n: i18n): ResourceConfig<NetworkPolicyMod
   initValue: NETWORK_POLICY_INIT_VALUE,
   Dropdown: K8sDropdown,
   formConfig: {
-    formType: FormType.MODAL,
+    formType: FormType.FORM,
+    formContainerType: FormContainerType.MODAL,
   },
 });

--- a/packages/refine/src/pages/pods/create/index.tsx
+++ b/packages/refine/src/pages/pods/create/index.tsx
@@ -1,8 +1,12 @@
 import { FormProps } from 'antd/lib/form';
-import React from 'react';
+import React, { useContext } from 'react';
 import { YamlForm } from 'src/components';
 import { POD_INIT_VALUE } from 'src/constants/k8s';
+import ConfigsContext from 'src/contexts/configs';
 
 export const PodForm: React.FC<FormProps> = () => {
-  return <YamlForm initialValuesForCreate={POD_INIT_VALUE} />;
+  const configs = useContext(ConfigsContext);
+  const config = configs['pods'];
+
+  return <YamlForm initialValuesForCreate={POD_INIT_VALUE} config={config} />;
 };

--- a/packages/refine/src/pages/secrets/index.ts
+++ b/packages/refine/src/pages/secrets/index.ts
@@ -5,7 +5,7 @@ import { SECRET_OPAQUE_INIT_VALUE } from 'src/constants/k8s';
 import { SecretDataGroup, BasicGroup } from '../../components/ShowContent';
 import { AgeColumnRenderer, DataKeysColumnRenderer } from '../../hooks/useEagleTable/columns';
 import { ResourceModel } from '../../models';
-import { RESOURCE_GROUP, ResourceConfig } from '../../types';
+import { FormType, RESOURCE_GROUP, ResourceConfig } from '../../types';
 
 function isBase64(value: string) {
   try {
@@ -25,6 +25,7 @@ export const SecretsConfig = (i18n: i18n): ResourceConfig<ResourceModel> => ({
   initValue: SECRET_OPAQUE_INIT_VALUE,
   columns: () => [DataKeysColumnRenderer(i18n), AgeColumnRenderer(i18n)],
   formConfig: {
+    formType: FormType.FORM,
     transformInitValues: (value) => {
       const data = (value as Secret).data || {};
 

--- a/packages/refine/src/pages/storageclasses/form/index.tsx
+++ b/packages/refine/src/pages/storageclasses/form/index.tsx
@@ -1,8 +1,8 @@
 import { Select, AntdOption } from '@cloudtower/eagle';
 import React from 'react';
 import i18n from 'src/i18n';
-import { ResourceModel } from 'src/models';
-import { ResourceConfig } from 'src/types';
+import { StorageClassModel } from 'src/models';
+import { FormType, ResourceConfig } from 'src/types';
 
 type GenerateStorageClassFormConfig = {
   isEnabledZbs?: boolean;
@@ -10,7 +10,7 @@ type GenerateStorageClassFormConfig = {
   isVmKsc?: boolean;
 }
 
-export function generateStorageClassFormConfig(options: GenerateStorageClassFormConfig): ResourceConfig<ResourceModel>['formConfig'] {
+export function generateStorageClassFormConfig(options: GenerateStorageClassFormConfig): ResourceConfig<StorageClassModel>['formConfig'] {
   const {
     isEnabledZbs,
     isVmKsc,
@@ -18,6 +18,7 @@ export function generateStorageClassFormConfig(options: GenerateStorageClassForm
   } = options;
 
   return {
+    formType: FormType.FORM,
     fields() {
       return [
         {

--- a/packages/refine/src/pages/storageclasses/index.ts
+++ b/packages/refine/src/pages/storageclasses/index.ts
@@ -7,16 +7,18 @@ import {
   AgeColumnRenderer,
   SCAllowExpandColumnRenderer
 } from 'src/hooks/useEagleTable/columns';
-import { RESOURCE_GROUP } from 'src/types';
+import { StorageClassModel } from 'src/models';
+import { RESOURCE_GROUP, ResourceConfig } from 'src/types';
 import { StorageClassProvisionerField } from '../../components';
 import { generateStorageClassFormConfig } from './form';
 
-export const StorageClassConfig = (i18n: I18n) => ({
+export const StorageClassConfig = (i18n: I18n): ResourceConfig<StorageClassModel> => ({
   name: 'storageclasses',
   basePath: '/apis/storage.k8s.io/v1',
   kind: 'StorageClass',
+  apiVersion: 'storage.k8s.io/v1',
   parent: RESOURCE_GROUP.STORAGE,
-  label: 'StorageClasses',
+  displayName: i18n.t('dovetail.storage_class'),
   initValue: STORAGE_CLASS_INIT_VALUE,
   formConfig: generateStorageClassFormConfig({
     isEnabledZbs: true,

--- a/packages/refine/src/types/resource.ts
+++ b/packages/refine/src/types/resource.ts
@@ -1,5 +1,4 @@
 import { UseFormProps } from '@refinedev/react-hook-form';
-import { YamlFormProps } from '../components';
 import { FormModalProps, RefineFormField } from '../components/Form';
 import { Column, InternalTableProps } from '../components/InternalBaseTable';
 import { ShowConfig } from '../components/ShowContent';
@@ -17,12 +16,127 @@ export enum RESOURCE_GROUP {
   PROJECT = 'PROJECT',
 }
 
-export enum FormType {
+/**
+ * 表单容器类型
+ */
+export enum FormContainerType {
   PAGE = 'PAGE',
   MODAL = 'MODAL',
 }
 
+/**
+ * 表单类型
+ */
+export enum FormType {
+  YAML = 'YAML',
+  FORM = 'FORM',
+}
+
+/**
+ * 允许切换的表单模式
+ */
+export enum FormMode {
+  FORM = 'FORM',
+  YAML = 'YAML',
+}
+
 export type WithId<T> = T & { id: string };
+
+export type RefineFormConfig<Model extends ResourceModel = ResourceModel> = {
+  formType: FormType.FORM;
+  /**
+ * 表单字段配置函数
+ * @param props 包含记录和动作类型的配置对象
+ * @returns 表单字段配置数组
+ */
+  fields?: (props: {
+    record?: Model;
+    records: Model[];
+    action: 'create' | 'edit';
+  }) => RefineFormField[];
+  /** Refine Core 的表单属性 */
+  refineCoreProps?: UseFormProps['refineCoreProps'];
+  /** React Hook Form 的配置属性 */
+  useFormProps?: UseFormProps;
+  /** 是否禁用切换表单模式（在 YAML 和表单之间切换） */
+  isDisabledChangeMode?: boolean;
+  /** 表单标签的宽度
+   * 默认是 216px
+   */
+  labelWidth?: string;
+  /**
+ * 自定义表单渲染函数
+ * @returns React节点
+ */
+  renderForm?: () => React.ReactNode;
+};
+
+export type YamlFormConfig = {
+  formType: FormType.YAML;
+};
+
+export type ErrorBody = {
+  kind: string;
+  apiVersion: string;
+  metadata: object;
+  status: string;
+  message: string;
+  reason: string;
+  details: {
+    name: string;
+    group: string;
+    kind: string;
+    causes?: {
+      reason: string;
+      message: string;
+      field: string;
+    }[];
+  };
+  code: number;
+};
+
+export type CommonFormConfig<Model extends ResourceModel = ResourceModel> = {
+  /** 自定义表单模态框组件 */
+  CustomFormModal?: React.FC<FormModalProps>;
+  /**
+   * 初始值转换函数
+   * @param values 原始值
+   * @returns 转换后的值
+   */
+  transformInitValues?: (values: Record<string, unknown>) => Record<string, unknown>;
+  /**
+   * 提交值转换函数，转换为 YAML 格式
+   * @param values 表单值
+   * @returns YAML格式的数据
+   */
+  transformApplyValues?: (values: Record<string, unknown>) => Model['_rawYaml'];
+  /** 表单容器类型：页面形式或模态框形式
+   * PAGE 或者 MODAL
+  */
+  formContainerType?: FormContainerType;
+  /**
+   * 表单标题，可以是字符串或根据操作类型返回不同标题的函数
+   * @param action 操作类型：create 或 edit
+   */
+  formTitle?: string | ((action: 'create' | 'edit') => string);
+  /**
+   * 表单描述，可以是字符串或根据操作类型返回不同描述的函数
+   * @param action 操作类型：create 或 edit
+   */
+  formDesc?: string | ((action: 'create' | 'edit') => string);
+  /** 保存按钮文本 */
+  saveButtonText?: string;
+  /**
+   * 错误信息格式化函数，待完善
+   * @param errorBody 错误信息体
+   * @returns 格式化后的错误信息
+   */
+  formatError?: (errorBody: ErrorBody) => string;
+  /**
+   * 路径映射，用于在表单中映射路径
+   */
+  pathMap?: { from: string[]; to: string[] }[];
+};
 
 export type ResourceConfig<Model extends ResourceModel = ResourceModel> = {
   /** 资源名称，用于 API 调用和路由。
@@ -80,72 +194,5 @@ export type ResourceConfig<Model extends ResourceModel = ResourceModel> = {
    */
   deleteTip?: string;
   /** 表单相关配置 */
-  formConfig?: {
-    /**
-     * 表单字段配置函数
-     * @param props 包含记录和动作类型的配置对象
-     * @returns 表单字段配置数组
-     */
-    fields?: (props: {
-      record?: Model;
-      records: Model[];
-      action: 'create' | 'edit';
-    }) => RefineFormField[];
-    /** 保存按钮文本 */
-    saveButtonText?: string;
-    /**
-     * 自定义表单渲染函数
-     * @param props YAML表单属性，待完善
-     * @returns React节点
-     */
-    renderForm?: (props: YamlFormProps) => React.ReactNode;
-    /** 表单类型：页面形式或模态框形式
-     * PAGE 或者 MODAL
-    */
-    formType?: FormType;
-    /**
-     * 初始值转换函数
-     * @param values 原始值
-     * @returns 转换后的值
-     */
-    transformInitValues?: (values: Record<string, unknown>) => Record<string, unknown>;
-    /**
-     * 提交值转换函数，转换为 YAML 格式
-     * @param values 表单值
-     * @returns YAML格式的数据
-     */
-    transformApplyValues?: (values: Record<string, unknown>) => Model['_rawYaml'];
-    /**
-     * 路径映射，用于在表单中映射路径
-     */
-    pathMap?: { from: string[]; to: string[] }[];
-    /**
-     * 表单标题，可以是字符串或根据操作类型返回不同标题的函数
-     * @param action 操作类型：create 或 edit
-     */
-    formTitle?: string | ((action: 'create' | 'edit') => string);
-    /**
-     * 表单描述，可以是字符串或根据操作类型返回不同描述的函数
-     * @param action 操作类型：create 或 edit
-     */
-    formDesc?: string | ((action: 'create' | 'edit') => string);
-    /** 表单标签的宽度
-     * 默认是 216px
-     */
-    labelWidth?: string;
-    /**
-     * 错误信息格式化函数，待完善
-     * @param errorBody 错误信息体
-     * @returns 格式化后的错误信息
-     */
-    formatError?: (errorBody: unknown) => string;
-    /** Refine Core 的表单属性 */
-    refineCoreProps?: UseFormProps['refineCoreProps'];
-    /** React Hook Form 的配置属性 */
-    useFormProps?: UseFormProps;
-    /** 是否禁用切换表单模式（在 YAML 和表单之间切换） */
-    isDisabledChangeMode?: boolean;
-    /** 自定义表单模态框组件 */
-    CustomFormModal?: React.FC<FormModalProps>;
-  };
+  formConfig?: (RefineFormConfig<Model> | YamlFormConfig) & CommonFormConfig<Model>;
 };


### PR DESCRIPTION
## 背景
之前 formConfig 中把 RefineForm 和 YAMLForm 的配置字段混杂在一起，不容易分清哪些字段分别是针对哪种表单类型生效的。

## 解决方案

### 表单配置调整
现在在 formConfig 需明确声明表单类型，然后根据表单类型的不同填写不同的配置。

```ts
export type DefaultFormConfig<Model extends ResourceModel = ResourceModel> = {
  formType: FormType.FORM;
  /**
 * 表单字段配置函数
 * @param props 包含记录和动作类型的配置对象
 * @returns 表单字段配置数组
 */
  fields?: (props: {
    record?: Model;
    records: Model[];
    action: 'create' | 'edit';
  }) => RefineFormField[];
  /** Refine Core 的表单属性 */
  refineCoreProps?: UseFormProps['refineCoreProps'];
  /** React Hook Form 的配置属性 */
  useFormProps?: UseFormProps;
  /** 是否禁用切换表单模式（在 YAML 和表单之间切换） */
  isDisabledChangeMode?: boolean;
  /** 表单标签的宽度
   * 默认是 216px
   */
  labelWidth?: string;
  /**
 * 自定义表单渲染函数
 * @returns React节点
 */
  renderForm?: () => React.ReactNode;
};

export type YamlFormConfig = {
  formType: FormType.YAML;
};

export type CommonFormConfig<Model extends ResourceModel = ResourceModel> = {
  /** 自定义表单模态框组件 */
  CustomFormModal?: React.FC<FormModalProps>;
  /**
   * 初始值转换函数
   * @param values 原始值
   * @returns 转换后的值
   */
  transformInitValues?: (values: Record<string, unknown>) => Record<string, unknown>;
  /**
   * 提交值转换函数，转换为 YAML 格式
   * @param values 表单值
   * @returns YAML格式的数据
   */
  transformApplyValues?: (values: Record<string, unknown>) => Model['_rawYaml'];
  /** 表单容器类型：页面形式或模态框形式
   * PAGE 或者 MODAL
  */
  formContainerType?: FormContainerType;
  /**
   * 表单标题，可以是字符串或根据操作类型返回不同标题的函数
   * @param action 操作类型：create 或 edit
   */
  formTitle?: string | ((action: 'create' | 'edit') => string);
  /**
   * 表单描述，可以是字符串或根据操作类型返回不同描述的函数
   * @param action 操作类型：create 或 edit
   */
  formDesc?: string | ((action: 'create' | 'edit') => string);
  /** 保存按钮文本 */
  saveButtonText?: string;
  /**
   * 错误信息格式化函数，待完善
   * @param errorBody 错误信息体
   * @returns 格式化后的错误信息
   */
  formatError?: (errorBody: unknown) => string;
};
```

### FormModal 调整

现在将表单的渲染逻辑拆分到 RefineFormContainer 和 YamlFormContainer 内部，并将对应的 formConfig 通过参数传入，这样在 RefineFormContainer 和 YamlFormContainer 不用先判断表单类型再获取配置字段。

```tsx
  const formEle = useMemo(() => {
    if (config.formConfig && (config.formConfig?.formType === FormType.FORM || 'fields' in config.formConfig)) {
      return <RefineFormContainer
        id={id as string}
        isYamlMode={isYamlMode}
        config={config}
        yamlFormProps={customYamlFormProps}
        formConfig={config.formConfig as DefaultFormConfig & CommonFormConfig}
        onSaveButtonPropsChange={setSaveButtonProps}
        onError={() => {
          setIsError(true);
        }}
        onSuccess={() => {
          setIsError(false);
          popModal();
        }}
      />;

    }

    return <YamlFormContainer
      id={id as string}
      customYamlFormProps={customYamlFormProps}
      config={config}
      formConfig={config.formConfig}
      onSuccess={() => {
        setIsError(false);
        popModal();
      }}
      onError={() => {
        setIsError(true);
      }}
    />;
  }, [id, customYamlFormProps, config, isYamlMode, popModal, setSaveButtonProps]);
```

### config 改为通过参数传入

由于 FormModal 支持传入 `resource` 来定义当前是哪个资源的表单，用来在当前资源页面打开其他资源的表单，所以 FormModal 内部使用的 config 都改为通过参数传入，而不是通过 `useContext` 和 `useResource` 进行获取。