### PR TITLE
feat: enhance the form linkage

### DIFF
--- a/packages/refine/src/components/Form/RefineFormContent.tsx
+++ b/packages/refine/src/components/Form/RefineFormContent.tsx
@@ -1,8 +1,10 @@
-import { Fields, Form, Space, Typo } from '@cloudtower/eagle';
-import { css, cx } from '@linaria/core';
+import { Fields, Form, Space } from '@cloudtower/eagle';
+import { css } from '@linaria/core';
 import { UseFormReturnType } from '@refinedev/react-hook-form';
+import { get } from 'lodash-es';
 import React from 'react';
 import { Controller } from 'react-hook-form';
+import { RefineFormFieldRenderProps } from 'src/components/Form/type';
 import { ResourceModel } from 'src/models';
 import { CommonFormConfig, FormType, RefineFormConfig, ResourceConfig } from 'src/types';
 import { FormErrorAlert } from '../FormErrorAlert';
@@ -16,103 +18,101 @@ type Props<Model extends ResourceModel> = {
   resourceId?: string;
 };
 
+export function renderCommonFormFiled(props: RefineFormFieldRenderProps) {
+  const { field, fieldConfig, action } = props;
+  const { value, onChange, onBlur, name } = field;
+
+  let ele = (
+    <Fields.String
+      placeholder={fieldConfig.placeholder}
+      input={{ value, onChange, onBlur, name, onFocus: () => null }}
+      meta={{}}
+    />
+  );
+
+  switch (fieldConfig.type) {
+    case 'number':
+      ele = (
+        <Fields.Integer
+          className={css`
+            max-width: 144px;
+          `}
+          placeholder={fieldConfig.placeholder}
+          input={{ value, onChange, onBlur, name, onFocus: () => null }}
+          meta={{}}
+        />
+      );
+  }
+
+  // editing name is not allowed
+  if (action === 'edit' && fieldConfig.disabledWhenEdit) {
+    ele = <div>{value}</div>;
+  }
+
+  return ele;
+}
+
 export const RefineFormContent = <Model extends ResourceModel>(props: Props<Model>) => {
   const { config, formResult, resourceId, errorMsgs, formConfig } = props;
-  const { control, getValues } = formResult;
+  const { control, getValues, watch, trigger } = formResult;
   const action = resourceId ? 'edit' : 'create';
+  const formValues = watch();
 
   const formFieldsConfig = useFieldsConfig(config, formConfig, resourceId);
 
-  const fields = formFieldsConfig?.map(c => {
-    return (
+  const fields = formFieldsConfig?.map(fieldConfig => {
+    const isDisplay = fieldConfig.condition?.(formValues, get(formValues, fieldConfig.path.join('.'))) !== false;
+
+    return isDisplay ? (
       <Controller
-        key={c.key}
+        key={fieldConfig.key}
         control={control}
-        name={c.path.join('.')}
+        name={fieldConfig.path.join('.')}
         rules={{
           validate(value) {
             const formValue = getValues();
-            if (!c.validators || c.validators.length === 0) return true;
-            for (const func of c.validators) {
+            if (!fieldConfig.validators || fieldConfig.validators.length === 0) return true;
+            for (const func of fieldConfig.validators) {
               const { isValid, errorMsg } = func(value, formValue, FormType.FORM);
               if (!isValid) return errorMsg;
             }
             return true;
           },
         }}
-        render={({ field: { onChange, onBlur, value, name }, fieldState }) => {
-          const formValue = getValues();
-          let ele = (
-            <Fields.String
-              placeholder={c.placeholder}
-              input={{ value, onChange, onBlur, name, onFocus: () => null }}
-              meta={{}}
-            />
-          );
-          switch (c.type) {
-            case 'number':
-              ele = (
-                <Fields.Integer
-                  className={css`
-                    max-width: 144px;
-                  `}
-                  placeholder={c.placeholder}
-                  input={{ value, onChange, onBlur, name, onFocus: () => null }}
-                  meta={{}}
-                />
-              );
-          }
+        render={({ field, fieldState }) => {
+          const renderProps: RefineFormFieldRenderProps = {
+            field,
+            fieldConfig,
+            action,
+            control,
+            trigger,
+          };
 
-          // editing name is not allowed
-          if (action === 'edit' && c.disabledWhenEdit) {
-            ele = <div>{value}</div>;
-          }
+          let ele = null;
 
-          if (c?.render) {
-            ele = c.render(value, onChange, formValue, onBlur, action, control);
-          }
-
-          // add helper text
-          if (c.helperText) {
-            ele = (
-              <Space
-                size={4}
-                direction="vertical"
-                className={css`
-                  width: 100%;
-                `}
-              >
-                {ele}
-                <div
-                  className={cx(
-                    Typo.Footnote.f2_regular,
-                    css`
-                      color: rgba(44, 56, 82, 0.6);
-                    `
-                  )}
-                >
-                  {c.helperText}
-                </div>
-              </Space>
-            );
+          if (fieldConfig?.render) {
+            ele = fieldConfig.render(renderProps);
+          } else {
+            ele = renderCommonFormFiled(renderProps);
           }
 
           return (
             <Form.Item
-              key={c.key}
-              label={c.label}
+              key={fieldConfig.key}
+              label={fieldConfig.label}
               colon={false}
               labelCol={{ flex: `0 0 ${formConfig?.labelWidth || '216px'}` }}
               help={fieldState.error?.message}
+              extra={fieldConfig.helperText}
               validateStatus={fieldState.invalid ? 'error' : undefined}
-              data-test-id={c.key}
+              data-test-id={fieldConfig.key}
             >
               {ele}
             </Form.Item>
           );
         }}
       />
-    );
+    ) : null;
   });
 
   return (

--- a/packages/refine/src/components/Form/type.ts
+++ b/packages/refine/src/components/Form/type.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Control } from 'react-hook-form';
+import { Control, UseFormTrigger, FieldValues, ControllerRenderProps } from 'react-hook-form';
 import { FormType } from 'src/types/resource';
 
 export type RefineFormValidator = (
@@ -7,6 +7,14 @@ export type RefineFormValidator = (
   formValue: unknown,
   formMode: FormType
 ) => { isValid: boolean; errorMsg: string };
+
+export type RefineFormFieldRenderProps = {
+  field: ControllerRenderProps<FieldValues, string>;
+  fieldConfig: RefineFormField;
+  action: 'edit' | 'create';
+  control: Control;
+  trigger: UseFormTrigger<FieldValues>;
+};
 
 export type RefineFormField = {
   path: string[];
@@ -17,12 +25,11 @@ export type RefineFormField = {
   type?: 'number';
   validators?: RefineFormValidator[];
   disabledWhenEdit?: boolean;
-  render?: (
-    value: unknown,
-    onChange: (event: unknown) => void,
-    formValue: unknown,
-    onBlur: () => void,
-    action: 'edit' | 'create',
-    control: Control,
-  ) => React.ReactElement;
+  render?: (props: RefineFormFieldRenderProps) => React.ReactElement;
+  /**
+   * 表单项条件渲染函数
+   * @param formValue 表单值
+   * @returns 是否渲染
+   */
+  condition?: (formValue: Record<string, unknown>, value: unknown) => boolean;
 };

--- a/packages/refine/src/pages/storageclasses/index.ts
+++ b/packages/refine/src/pages/storageclasses/index.ts
@@ -21,8 +21,8 @@ export const StorageClassConfig = (i18n: I18n): ResourceConfig<StorageClassModel
   displayName: i18n.t('dovetail.storage_class'),
   initValue: STORAGE_CLASS_INIT_VALUE,
   formConfig: generateStorageClassFormConfig({
-    isEnabledZbs: true,
-    isEnabledElf: false,
+    isEnabledProvisionerA: true,
+    isEnabledProvisionerB: false,
     isVmKsc: true,
   }),
   columns: () => [


### PR DESCRIPTION
根据 https://github.com/webzard-io/dovetail-v2/issues/228 实现表单联动。

### 其他改动

#### 整理 render 函数参数。

之前的参数是按顺序一个个传的，现在参数变多之后不好读取，统一改成在一个对象里传。

```ts
// 移除了 formValue，因为从 `getValues` 中读取的不是响应式的，如果组件内需要可以使用 useWatch 进行读取
export type RefineFormFieldRenderProps = {
  field: ControllerRenderProps<FieldValues, string>;
  fieldConfig: RefineFormField;
  action: 'edit' | 'create';
  control: Control;
  trigger: UseFormTrigger<FieldValues>;
};
```

#### helpText 渲染
改为直接使用 `extra` 属性来渲染，不用另写渲染逻辑