### PR TITLE
feat: enhance MonacoYamlEditor with schema management and value synchronization

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.2.1",
+  "version": "0.2.2-alpha.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/src/types/window.d.ts
+++ b/packages/refine/src/types/window.d.ts
@@ -2,4 +2,11 @@ interface Window {
   MonacoEnvironment: {
     getWorker: (_: unknown, label: string) => unknown;
   };
+  _MonacoSchemaMap: Map<string, {
+    uri: string;
+    fileMatch: string[];
+    schema: {
+      oneOf: JSONSchema7[];
+    };
+  }>;
 }


### PR DESCRIPTION
### 编辑器支持可控模式

传入 value 来改变编辑器的值。

### schemaMap 设置

由于 Monaco 的 setDiagnosticsOptions 是设置全局配置的，不同项目间多次调用 setDiagnosticsOptions 会有冲突问题。

现在把 schemaMap 移到 window 下供其他项目获取，设置完整的 schemas。