### PR TITLE
feat: support custom displayName in show

### DIFF
--- a/packages/refine/src/components/ShowContent/ShowContent.tsx
+++ b/packages/refine/src/components/ShowContent/ShowContent.tsx
@@ -278,7 +278,7 @@ export const ShowContent = <Model extends ResourceModel>(props: Props<Model>) =>
       <Space className={TopBarStyle}>
         <div style={{ display: 'flex' }}>
           <span className={cx(Typo.Display.d2_regular_title, NameStyle)}>
-            {record?.metadata?.name}
+            {showConfig.displayName?.(record) || record?.metadata?.name}
           </span>
           {stateDisplay ? (
             <StateTag

--- a/packages/refine/src/components/ShowContent/fields.tsx
+++ b/packages/refine/src/components/ShowContent/fields.tsx
@@ -97,6 +97,7 @@ export interface ShowConfig<Model extends ResourceModel = ResourceModel> {
     color: Record<string, StatusCapsuleColor | 'loading'>;
     text: Record<string, string>;
   };
+  displayName?: (record: Model) => string | undefined;
 }
 
 export const ImageField = <Model extends WorkloadBaseModel>(


### PR DESCRIPTION
 支持在详情页展示自定义的名字，而不是固定的metadata.name