### PR TITLE
Bowen/export

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/src/components/ShowContent/ShowContent.tsx
+++ b/packages/refine/src/components/ShowContent/ShowContent.tsx
@@ -219,7 +219,7 @@ export const ShowContent = <Model extends ResourceModel>(props: Props<Model>) =>
         <Col
           flex={areaType === AreaType.Inline ? 'none' : ''}
           span={field.col || 24}
-          key={field.path.join()}
+          key={field.key}
         >
           {field.render ? (
             field.render(value, record, field)

--- a/packages/refine/src/utils/index.ts
+++ b/packages/refine/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './schema';
 export * from './k8s';
+export * from './match-selector';


### PR DESCRIPTION
用path作为key的话，当两个filed的path都是空数组，key就重复了。修复一下。