### PR TITLE
Bowen/160

### DIFF
--- a/packages/refine/__tests__/plugins/model.spec.ts
+++ b/packages/refine/__tests__/plugins/model.spec.ts
@@ -14,7 +14,7 @@ describe('PodModel', () => {
     expect(podModel.imageNames).toEqual([
       'quay.io/jetstack/cert-manager-controller:v1.8.0',
     ]);
-    expect(podModel.restartCount).toEqual(5);
+    expect(podModel.restarts).toEqual(5);
     expect(podModel.readyDisplay).toEqual('1/1');
     expect(podModel.name).toEqual('cert-manager-7d6d974dbf-drn4r');
     expect(podModel.spec!.restartPolicy).toEqual('Always');

--- a/packages/refine/src/components/CreateButton/index.tsx
+++ b/packages/refine/src/components/CreateButton/index.tsx
@@ -24,7 +24,7 @@ export function CreateButton(props: CreateButtonProps) {
     <Button
       prefixIcon={<PlusAddCreateNew16BoldOntintIcon />}
       type="primary"
-      onClick={openForm}
+      onClick={() => openForm()}
     >
       {createButtonText ||
         t('dovetail.create_resource', {

--- a/packages/refine/src/components/Dropdowns/K8sDropdown/index.tsx
+++ b/packages/refine/src/components/Dropdowns/K8sDropdown/index.tsx
@@ -17,6 +17,7 @@ import { useDeleteModal } from 'src/hooks/useDeleteModal';
 import { useDownloadYAML } from 'src/hooks/useDownloadYAML';
 import { useOpenForm } from 'src/hooks/useOpenForm';
 import { FormType } from 'src/types';
+import { getResourceNameByKind } from 'src/utils';
 import { useGlobalStore } from '../../../hooks';
 import { ResourceModel } from '../../../models';
 export type DropdownSize = 'normal' | 'large';
@@ -30,23 +31,23 @@ export function K8sDropdown(props: React.PropsWithChildren<K8sDropdownProps>) {
   const { record, size = 'normal' } = props;
   const globalStore = useGlobalStore();
   const useResourceResult = useResource();
-  const resource = useResourceResult.resource;
   const configs = useContext(ConfigsContext);
-  const config = configs[resource?.name || ''];
+  const resourceName = getResourceNameByKind(record.kind || '', configs);
+  const config = configs[resourceName || ''];
   const { t } = useTranslation();
-  const { openDeleteConfirmModal } = useDeleteModal({resourceName: resource?.name || ''});
+  const { openDeleteConfirmModal } = useDeleteModal({resourceName: resourceName || ''});
   const download = useDownloadYAML();
   const openForm = useOpenForm({ id: record.id });
   const isInShowPage = useResourceResult.action === 'show';
   const { data: canEditData } = useCan({
-    resource: resource?.name,
+    resource: resourceName,
     action: AccessControlAuth.Edit,
     params: {
       namespace: record.namespace,
     },
   });
   const { data: canDeleteData } = useCan({
-    resource: resource?.name,
+    resource: resourceName,
     action: AccessControlAuth.Delete,
     params: {
       namespace: record.namespace,

--- a/packages/refine/src/components/Dropdowns/K8sDropdown/index.tsx
+++ b/packages/refine/src/components/Dropdowns/K8sDropdown/index.tsx
@@ -61,7 +61,7 @@ export function K8sDropdown(props: React.PropsWithChildren<K8sDropdownProps>) {
         overlay={
           <Menu>
             {isInShowPage || canEditData?.can === false || config.hideEdit ? null : (
-              <Menu.Item onClick={openForm}>
+              <Menu.Item onClick={() => openForm()}>
                 <Icon src={EditPen16PrimaryIcon}>
                   {formType === FormType.FORM
                     ? t('dovetail.edit')

--- a/packages/refine/src/components/IngressRulesComponent/index.tsx
+++ b/packages/refine/src/components/IngressRulesComponent/index.tsx
@@ -31,7 +31,7 @@ export const IngressRulesComponent: React.FC<{
             {r.serviceName ? (
               <>
                 <ResourceLink
-                  resourceKind="services"
+                  resourceName="services"
                   namespace={ingress.metadata.namespace || 'default'}
                   name={r.serviceName}
                 />

--- a/packages/refine/src/components/IngressRulesTable/IngressRulesTable.tsx
+++ b/packages/refine/src/components/IngressRulesTable/IngressRulesTable.tsx
@@ -68,7 +68,7 @@ export const IngressRulesTable: React.FC<Props> = ({ ingress }) => {
       render: (serviceName: string, record: RuleItem) => {
         return record.serviceName ? (
           <ResourceLink
-            resourceKind="services"
+            resourceName="services"
             namespace={ingress.metadata.namespace || 'default'}
             name={serviceName}
           />
@@ -94,7 +94,7 @@ export const IngressRulesTable: React.FC<Props> = ({ ingress }) => {
 
         return secretName ? (
           <ResourceLink
-            resourceKind="secrets"
+            resourceName="secrets"
             namespace={ingress.metadata.namespace || 'default'}
             name={secretName}
           />

--- a/packages/refine/src/components/PodContainersTable/PodContainersTable.tsx
+++ b/packages/refine/src/components/PodContainersTable/PodContainersTable.tsx
@@ -71,13 +71,13 @@ export const PodContainersTable: React.FC<Props> = ({
         },
       },
       {
-        key: 'restartCount',
-        dataIndex: ['restartCount'],
+        key: 'restarts',
+        dataIndex: ['restarts'],
         title: i18n.t('dovetail.restarts'),
         sortable: true,
         align: 'right',
         width: 120,
-        sorter: CommonSorter(['restartCount']),
+        sorter: CommonSorter(['restarts']),
       },
       {
         key: 'started',

--- a/packages/refine/src/components/ReferenceLink/index.tsx
+++ b/packages/refine/src/components/ReferenceLink/index.tsx
@@ -27,7 +27,7 @@ export const ReferenceLink: React.FC<Props> = props => {
   return (
     <ResourceLink
       name={ownerReference.name}
-      resourceKind={resource.name || ''}
+      resourceName={resource.name || ''}
       namespace={namespace}
     />
   );

--- a/packages/refine/src/components/ResourceLink/index.tsx
+++ b/packages/refine/src/components/ResourceLink/index.tsx
@@ -6,7 +6,7 @@ import { AccessControlAuth } from 'src/constants';
 import { ValueDisplay } from '../ValueDisplay';
 
 type Props = {
-  resourceKind: string;
+  resourceName: string;
   namespace: string;
   name: string;
   displayName?: string;
@@ -18,7 +18,7 @@ const LinkStyle = css`
 `;
 
 export const ResourceLink: React.FC<Props> = props => {
-  const { resourceKind: resourceName, namespace, name, uid, displayName } = props;
+  const { resourceName, namespace, name, uid, displayName } = props;
   const navigation = useNavigation();
   const go = useGo();
 

--- a/packages/refine/src/components/ShowContent/ShowContent.tsx
+++ b/packages/refine/src/components/ShowContent/ShowContent.tsx
@@ -297,7 +297,7 @@ export const ShowContent = <Model extends ResourceModel>(props: Props<Model>) =>
                 namespace: record.namespace,
               }}
             >
-              <Button style={{ marginRight: 8 }} onClick={openForm}>
+              <Button style={{ marginRight: 8 }} onClick={() => openForm()}>
                 {config.formConfig?.formType === FormType.FORM
                   ? t('dovetail.edit')
                   : t('dovetail.edit_yaml')}

--- a/packages/refine/src/components/ShowContent/fields.tsx
+++ b/packages/refine/src/components/ShowContent/fields.tsx
@@ -489,7 +489,7 @@ export const PVRefField = <Model extends PersistentVolumeClaimModel>(
     renderContent(value) {
       return (
         <ResourceLink
-          resourceKind="persistentvolumes"
+          resourceName="persistentvolumes"
           namespace=""
           name={value as string}
         />
@@ -509,7 +509,7 @@ export const PVStorageClassField = <
     title: i18n.t('dovetail.storage_class'),
     renderContent(value) {
       return (
-        <ResourceLink resourceKind="storageclasses" namespace="" name={value as string} />
+        <ResourceLink resourceName="storageclasses" namespace="" name={value as string} />
       );
     },
   };
@@ -592,7 +592,7 @@ export const PVCRefField = <Model extends PersistentVolumeModel>(
     renderContent(value, pv) {
       return (
         <ResourceLink
-          resourceKind="persistentvolumeclaims"
+          resourceName="persistentvolumeclaims"
           namespace={pv.pvcNamespace || 'default'}
           name={value as string}
           uid={pv.pvcUid}

--- a/packages/refine/src/components/WorkloadPodsTable/WorkloadPodsTable.tsx
+++ b/packages/refine/src/components/WorkloadPodsTable/WorkloadPodsTable.tsx
@@ -10,7 +10,7 @@ import { matchSelector } from 'src/utils/match-selector';
 import {
   NameColumnRenderer,
   NodeNameColumnRenderer,
-  RestartCountColumnRenderer,
+  RestartsColumnRenderer,
   StateDisplayColumnRenderer,
   WorkloadImageColumnRenderer,
   PodContainersNumColumnRenderer,
@@ -56,7 +56,7 @@ export const WorkloadPodsTable: React.FC<WorkloadPodsTableProps> = ({
     hideNodeColumn ? undefined : NodeNameColumnRenderer(i18n),
     WorkloadImageColumnRenderer(i18n),
     PodContainersNumColumnRenderer(i18n),
-    RestartCountColumnRenderer(i18n),
+    RestartsColumnRenderer(i18n),
     AgeColumnRenderer(i18n),
   ].filter(v => !!v) as Column<PodModel>[];
 

--- a/packages/refine/src/hooks/useEagleTable/columns.tsx
+++ b/packages/refine/src/hooks/useEagleTable/columns.tsx
@@ -86,7 +86,12 @@ const NameLink: React.FC<{ id: string; name: string; resource?: string }> = prop
 export const CommonSorter = (dataIndex: string[]) => (a: unknown, b: unknown) => {
   const valA = get(a, dataIndex);
   const valB = get(b, dataIndex);
+  
+  // 处理 undefined 值的情况
   if (valA === valB) return 0;
+  if (valA !== undefined && valB === undefined) return 1; // undefined 更小
+  if (valA === undefined && valB !== undefined) return -1;
+
   if (valA > valB) return 1;
   return -1;
 };

--- a/packages/refine/src/hooks/useEagleTable/columns.tsx
+++ b/packages/refine/src/hooks/useEagleTable/columns.tsx
@@ -195,7 +195,11 @@ export const WorkloadRestartsColumnRenderer = <Model extends WorkloadModel>(
     width: 120,
     dataIndex,
     align: 'right',
+    sorter: CommonSorter(dataIndex),
     title: i18n.t('dovetail.restarts'),
+    render: (value: number) => {
+      return <ValueDisplay value={value} />;
+    },
   };
 };
 

--- a/packages/refine/src/hooks/useEagleTable/columns.tsx
+++ b/packages/refine/src/hooks/useEagleTable/columns.tsx
@@ -270,7 +270,7 @@ export const NodeNameColumnRenderer = <Model extends PodModel>(
     width: 160,
     sorter: CommonSorter(dataIndex),
     render: v => {
-      return <ResourceLink resourceKind="nodes" name={v} namespace="" />;
+      return <ResourceLink resourceName="nodes" name={v} namespace="" />;
     },
     ...options,
   };
@@ -673,7 +673,7 @@ export const PVRefColumnRenderer = <Model extends PersistentVolumeClaimModel>(
     width: 160,
     sortable: true,
     render(value) {
-      return <ResourceLink resourceKind="persistentvolumes" namespace="" name={value} />;
+      return <ResourceLink resourceName="persistentvolumes" namespace="" name={value} />;
     },
   };
 };
@@ -691,7 +691,7 @@ export const PVStorageClassColumnRenderer = <
     width: 160,
     sortable: true,
     render(value) {
-      return <ResourceLink resourceKind="storageclasses" namespace="" name={value} />;
+      return <ResourceLink resourceName="storageclasses" namespace="" name={value} />;
     },
   };
 };
@@ -727,7 +727,7 @@ export const PVCRefColumnRenderer = <Model extends PersistentVolumeModel>(
     render(value, pv) {
       return (
         <ResourceLink
-          resourceKind="persistentvolumeclaims"
+          resourceName="persistentvolumeclaims"
           namespace={pv.pvcNamespace || 'default'}
           name={value}
           uid={pv.pvcUid}

--- a/packages/refine/src/hooks/useEagleTable/columns.tsx
+++ b/packages/refine/src/hooks/useEagleTable/columns.tsx
@@ -185,7 +185,7 @@ export const WorkloadImageColumnRenderer = <Model extends WorkloadBaseModel>(
   };
 };
 
-export const WorkloadRestartsColumnRenderer = <Model extends WorkloadModel>(
+export const RestartsColumnRenderer = <Model extends WorkloadModel>(
   i18n: I18nType
 ): Column<Model> => {
   const dataIndex = ['restarts'];
@@ -195,6 +195,7 @@ export const WorkloadRestartsColumnRenderer = <Model extends WorkloadModel>(
     width: 120,
     dataIndex,
     align: 'right',
+    sortable: true,
     sorter: CommonSorter(dataIndex),
     title: i18n.t('dovetail.restarts'),
     render: (value: number) => {
@@ -277,22 +278,6 @@ export const NodeNameColumnRenderer = <Model extends PodModel>(
       return <ResourceLink resourceName="nodes" name={v} namespace="" />;
     },
     ...options,
-  };
-};
-
-export const RestartCountColumnRenderer = <Model extends PodModel>(
-  i18n: I18nType
-): Column<Model> => {
-  const dataIndex = ['restartCount'];
-  return {
-    key: 'restartCount',
-    display: true,
-    dataIndex,
-    title: i18n.t('dovetail.restarts'),
-    sortable: true,
-    width: 120,
-    align: 'right',
-    sorter: CommonSorter(dataIndex),
   };
 };
 

--- a/packages/refine/src/hooks/useNamespaceRefineFilter.tsx
+++ b/packages/refine/src/hooks/useNamespaceRefineFilter.tsx
@@ -4,18 +4,28 @@ import { useNamespacesFilter, ALL_NS } from 'src/components/NamespacesFilter';
 
 function useNamespaceRefineFilter() {
   const { value: nsFilters = [] } = useNamespacesFilter();
-  const filters = useMemo(() => ({
-    permanent: [
-      {
-        operator: 'or',
-        value: nsFilters.filter(filter => filter !== ALL_NS).map(filter => ({
-          field: 'metadata.namespace',
-          operator: 'eq',
-          value: filter,
-        }))
-      }
-    ] as CrudFilters,
-  }), [nsFilters]);
+  const filters = useMemo(() => {
+    const filters = nsFilters.filter(filter => filter !== ALL_NS);
+    if (filters.length === 0) {
+      return {
+        permanent: [],
+      };
+    }
+
+    return {
+      permanent: [
+        {
+          operator: 'or',
+          value: filters
+            .map(filter => ({
+              field: 'metadata.namespace',
+              operator: 'eq',
+              value: filter,
+            })),
+        },
+      ] as CrudFilters,
+    };
+  }, [nsFilters]);
 
   return filters;
 }

--- a/packages/refine/src/hooks/useOpenForm.ts
+++ b/packages/refine/src/hooks/useOpenForm.ts
@@ -19,16 +19,17 @@ export function useOpenForm(options?: UseOpenFormOptions) {
   const pushModal = usePushModal();
   const go = useGo();
 
-  return function openForm() {
-    if (resource?.name) {
-      const config = configs[resource.name];
+  return function openForm(resourceName?: string) {
+    const finalResourceName = resourceName || resource?.name;
+    if (finalResourceName) {
+      const config = configs[finalResourceName];
       const formType = config.formConfig?.formContainerType;
 
       if (formType === undefined || formType === FormContainerType.MODAL) {
         pushModal<'FormModal'>({
           component: config.formConfig?.CustomFormModal || FormModal,
           props: {
-            resource: resource.name,
+            resource: finalResourceName,
             id: options?.id,
             formProps: {
               initialValues: getInitialValues(config),
@@ -39,7 +40,7 @@ export function useOpenForm(options?: UseOpenFormOptions) {
         edit(options.id);
       } else {
         go({
-          to: navigation.createUrl(resource.name),
+          to: navigation.createUrl(finalResourceName),
           options: {
             keepQuery: true,
           },

--- a/packages/refine/src/models/job-model.ts
+++ b/packages/refine/src/models/job-model.ts
@@ -34,7 +34,7 @@ export class JobModel extends WorkloadBaseModel {
     const myPods = pods.items.filter(p =>
       matchSelector(p as PodModel, this.spec?.selector, this.metadata.namespace)
     );
-    const result = sumBy(myPods, 'restartCount');
+    const result = sumBy(myPods, 'restarts');
     this.restarts = result;
   }
 

--- a/packages/refine/src/models/pod-model.ts
+++ b/packages/refine/src/models/pod-model.ts
@@ -71,7 +71,7 @@ export class PodModel extends WorkloadBaseModel {
     );
   }
 
-  get restartCount() {
+  get restarts() {
     if (this._rawYaml.status?.containerStatuses) {
       return this._rawYaml.status?.containerStatuses.reduce((count, container) => {
         count += container.restartCount;

--- a/packages/refine/src/models/workload-model.ts
+++ b/packages/refine/src/models/workload-model.ts
@@ -45,6 +45,10 @@ export class WorkloadModel extends WorkloadBaseModel {
     return this.status && 'readyReplicas' in this.status ? this.status.readyReplicas : 0;
   }
 
+  get appKey() {
+    return `${this.kind}-${this.name}-${this.namespace}`;
+  }
+
   redeploy(): WorkloadTypes {
     const rawYaml = this._globalStore.restoreItem(this);
     const newOne = cloneDeep(rawYaml);

--- a/packages/refine/src/models/workload-model.ts
+++ b/packages/refine/src/models/workload-model.ts
@@ -33,7 +33,7 @@ export class WorkloadModel extends WorkloadBaseModel {
     const myPods = pods.items.filter(p =>
       matchSelector(p as PodModel, this.spec?.selector, this.metadata.namespace)
     );
-    const result = sumBy(myPods, 'restartCount');
+    const result = sumBy(myPods, 'restarts');
     this.restarts = result;
   }
 

--- a/packages/refine/src/pages/daemonsets/list/index.tsx
+++ b/packages/refine/src/pages/daemonsets/list/index.tsx
@@ -10,7 +10,7 @@ import {
   NameColumnRenderer,
   NameSpaceColumnRenderer,
   StateDisplayColumnRenderer,
-  WorkloadRestartsColumnRenderer,
+  RestartsColumnRenderer,
   ReplicasColumnRenderer,
 } from 'src/hooks/useEagleTable/columns';
 import { WorkloadModel } from '../../../models';
@@ -25,7 +25,7 @@ export const DaemonSetList: React.FC<IResourceComponentsProps> = () => {
       NameSpaceColumnRenderer(i18n),
       WorkloadImageColumnRenderer(i18n),
       ReplicasColumnRenderer(i18n),
-      WorkloadRestartsColumnRenderer(i18n),
+      RestartsColumnRenderer(i18n),
       AgeColumnRenderer(i18n),
     ],
     tableProps: {

--- a/packages/refine/src/pages/deployments/list/index.tsx
+++ b/packages/refine/src/pages/deployments/list/index.tsx
@@ -10,7 +10,7 @@ import {
   NameColumnRenderer,
   NameSpaceColumnRenderer,
   ReplicasColumnRenderer,
-  WorkloadRestartsColumnRenderer,
+  RestartsColumnRenderer,
   StateDisplayColumnRenderer,
 } from 'src/hooks/useEagleTable/columns';
 import { DeploymentModel } from '../../../models';
@@ -24,7 +24,7 @@ export const DeploymentList: React.FC<IResourceComponentsProps> = () => {
       NameColumnRenderer(i18n),
       NameSpaceColumnRenderer(i18n),
       WorkloadImageColumnRenderer(i18n),
-      WorkloadRestartsColumnRenderer(i18n),
+      RestartsColumnRenderer(i18n),
       ReplicasColumnRenderer(i18n),
       AgeColumnRenderer(i18n),
     ],

--- a/packages/refine/src/pages/jobs/index.ts
+++ b/packages/refine/src/pages/jobs/index.ts
@@ -17,7 +17,7 @@ import {
   DurationColumnRenderer,
   CompletionsCountColumnRenderer,
   StateDisplayColumnRenderer,
-  WorkloadRestartsColumnRenderer,
+  RestartsColumnRenderer,
 } from '../../hooks/useEagleTable/columns';
 import { JobModel } from '../../models';
 import { RESOURCE_GROUP, ResourceConfig, FormType } from '../../types';
@@ -33,7 +33,7 @@ export const JobConfig = (i18n: i18n): ResourceConfig<JobModel> => ({
       StateDisplayColumnRenderer(i18n),
       WorkloadImageColumnRenderer(i18n),
       CompletionsCountColumnRenderer(i18n),
-      WorkloadRestartsColumnRenderer(i18n),
+      RestartsColumnRenderer(i18n),
       DurationColumnRenderer(i18n),
       AgeColumnRenderer(i18n),
     ] as Column<JobModel>[],

--- a/packages/refine/src/pages/pods/list/index.tsx
+++ b/packages/refine/src/pages/pods/list/index.tsx
@@ -12,7 +12,7 @@ import {
   NameColumnRenderer,
   NameSpaceColumnRenderer,
   CommonSorter,
-  RestartCountColumnRenderer,
+  RestartsColumnRenderer,
   NodeNameColumnRenderer,
   StateDisplayColumnRenderer,
   PodWorkloadColumnRenderer,
@@ -53,7 +53,7 @@ export const PodList: React.FC<IResourceComponentsProps> = () => {
       NameSpaceColumnRenderer(i18n),
       WorkloadImageColumnRenderer(i18n),
       PodContainersNumColumnRenderer(i18n),
-      RestartCountColumnRenderer(i18n),
+      RestartsColumnRenderer(i18n),
       NodeNameColumnRenderer(i18n),
       PodWorkloadColumnRenderer(i18n),
       supportMetrics && {

--- a/packages/refine/src/pages/statefulsets/index.ts
+++ b/packages/refine/src/pages/statefulsets/index.ts
@@ -16,7 +16,7 @@ import {
   NameSpaceColumnRenderer,
   StateDisplayColumnRenderer,
   ReplicasColumnRenderer,
-  WorkloadRestartsColumnRenderer,
+  RestartsColumnRenderer,
 } from 'src/hooks/useEagleTable/columns';
 import { StatefulSetModel } from 'src/models/statefulset-model';
 import { ResourceConfig } from 'src/types';
@@ -33,7 +33,7 @@ export const StatefulSetConfig = (i18n: i18n): ResourceConfig<StatefulSetModel> 
     StateDisplayColumnRenderer(i18n),
     NameSpaceColumnRenderer(i18n),
     WorkloadImageColumnRenderer(i18n),
-    WorkloadRestartsColumnRenderer(i18n),
+    RestartsColumnRenderer(i18n),
     ReplicasColumnRenderer(i18n),
     AgeColumnRenderer(i18n),
   ]),

--- a/packages/refine/src/utils/getResourceNameByKind.ts
+++ b/packages/refine/src/utils/getResourceNameByKind.ts
@@ -1,0 +1,8 @@
+import { ResourceConfig } from 'src/types';
+
+export function getResourceNameByKind(
+  kind: string,
+  configs: Record<string, ResourceConfig>
+) {
+  return Object.values(configs).find(config => config.kind === kind)?.name;
+}

--- a/packages/refine/src/utils/index.ts
+++ b/packages/refine/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './schema';
 export * from './k8s';
 export * from './match-selector';
+export * from './getResourceNameByKind';


### PR DESCRIPTION

### 1. **d60bb57** - feat: add getResourceNameByKind function
**新增功能：根据资源种类获取资源名称的工具函数**
- 新增 `getResourceNameByKind.ts` 工具函数，根据 Kubernetes 资源的 `kind` 查找配置中对应的资源名称
- 在 `K8sDropdown` 组件中使用这个新函数，替代直接使用 `resource?.name`
- 优化了权限检查和删除操作的资源名称获取逻辑

### 2. **5fbf579** - feat: add appKey in workload-model  
**新增功能：为工作负载模型添加应用唯一标识**
- 在 `WorkloadModel` 类中新增 `appKey` getter 方法
- `appKey` 格式为 `${kind}-${name}-${namespace}`，用于唯一标识应用

### 3. **33376b6** - feat: useOpenForm support assign resource name  
**新增功能：useOpenForm 钩子支持指定资源名称**
- 修改 `useOpenForm` 钩子，支持传入自定义资源名称参数
- 更新了多个组件调用方式：`CreateButton`、`K8sDropdown`、`ShowContent`
- 增强了表单打开功能的灵活性

### 4. **1ac33ad** - refactor: ResourceName resourceKind->resourceName
**重构：统一属性命名 resourceKind 改为 resourceName**
- 将 `ResourceLink` 组件的 `resourceKind` 属性重命名为 `resourceName`
- 更新了所有使用该组件的地方，包括：
  - 入口规则组件、资源链接组件
  - 显示内容字段、表格列渲染器
- 提高了代码一致性和可读性

### 5. 9065971 - fix: dont return filters when namespace is _all
修复：命名空间为 _all 时不返回过滤器
- 修复 `useNamespaceRefineFilter` 钩子的逻辑
- 当命名空间过滤器为空或只包含 `_all` 时，返回空的过滤器数组
- 避免了不必要的过滤条件

### 6. 6835af0 - fix: restart column show '-'
修复：重启次数列显示 '-' 的问题
- 为 `WorkloadRestartsColumnRenderer` 添加 `render` 函数
- 使用 `ValueDisplay` 组件正确显示重启次数，空值时显示 '-'
- 添加了排序功能

### 7. 664a998 - refactor: restartCount -> restarts
重构：属性名统一 restartCount 改为 restarts
- 将 Pod 模型中的 `restartCount` getter 重命名为 `restarts`
- 更新所有引用该属性的地方，包括：
  - 测试文件、组件表格、模型类
  - 页面列表配置、列渲染器
- 统一了重启次数属性的命名规范

### 8. 34e4176 - fix: fix CommonSorter undefined value bug
修复：CommonSorter 处理 undefined 值的 bug
- 修复表格排序器处理 `undefined` 值时的逻辑错误
- 添加对 `undefined` 值的特殊处理：
  - `undefined` 值被视为最小值
  - 避免了排序时的异常行为
