### PR TITLE
Bowen/showcontentview

### DIFF
--- a/packages/refine/src/components/PageShow/PageShow.tsx
+++ b/packages/refine/src/components/PageShow/PageShow.tsx
@@ -6,11 +6,11 @@ import { ConfigsContext } from 'src/contexts';
 import { ResourceModel } from '../../models';
 import { ShowContent, ShowConfig } from '../ShowContent';
 
-type Props<Model extends ResourceModel> = {
+type Props<Model extends ResourceModel> = React.PropsWithChildren<{
   showConfig: ShowConfig<Model>;
   formatter?: (r: Model) => Model;
   Dropdown?: React.FC<{ record: Model }>;
-};
+}>;
 
 export const PageShow = <Model extends ResourceModel>(props: Props<Model>) => {
   const parsed = useParsed();
@@ -64,5 +64,5 @@ export const PageShow = <Model extends ResourceModel>(props: Props<Model>) => {
     }
   }, [isError, nav, resource, queryResult, parsed, msg, notExistMsg, isLoading]);
 
-  return isLoading ? <Loading /> : <ShowContent {...props} />;
+  return isLoading ? <Loading /> : <ShowContent {...props}>{props.children}</ShowContent>;
 };

--- a/packages/refine/src/components/PodLog/index.tsx
+++ b/packages/refine/src/components/PodLog/index.tsx
@@ -5,7 +5,6 @@ import {
 } from '@cloudtower/icons-react';
 import { css } from '@linaria/core';
 import { LogViewer } from '@patternfly/react-log-viewer';
-import { useDataProvider } from '@refinedev/core';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ErrorContent from 'src/components/ErrorContent';
@@ -14,7 +13,6 @@ import '@patternfly/react-core/dist/styles/base-no-reset.css';
 import { PodModel } from '../../models';
 
 const WrapperStyle = css`
-  padding: 0 24px;
   height: 100%;
   display: flex;
   flex-direction: column;
@@ -39,7 +37,7 @@ const ContentStyle = css`
   min-height: 0;
 `;
 
-export const PodLog: React.FC<{ pod: PodModel }> = ({ pod }) => {
+export const PodLog: React.FC<{ pod: PodModel, apiUrl: string }> = ({ pod, apiUrl }) => {
   const [selectedContainer, setSelectedContainer] = useState(
     pod.spec?.containers[0]?.name || ''
   );
@@ -50,9 +48,6 @@ export const PodLog: React.FC<{ pod: PodModel }> = ({ pod }) => {
   const [wrap, setWrap] = useState(false);
   const logViewerRef = useRef<{ scrollToBottom: () => void }>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
-
-  const dataProvider = useDataProvider();
-  const apiUrl = dataProvider()['getApiUrl']();
 
   const { t } = useTranslation();
 

--- a/packages/refine/src/components/ShowContent/ShowContent.tsx
+++ b/packages/refine/src/components/ShowContent/ShowContent.tsx
@@ -4,13 +4,12 @@ import K8sDropdown from 'src/components/Dropdowns/K8sDropdown';
 import { ResourceModel } from '../../models';
 import { ShowContentView, ShowContentViewProps } from './ShowContentView';
 
-type Props<Model extends ResourceModel> = Omit<
-  ShowContentViewProps<Model>,
-  'id' | 'resourceName'
+type Props<Model extends ResourceModel> = React.PropsWithChildren<
+  Omit<ShowContentViewProps<Model>, 'id' | 'resourceName'>
 >;
 
 export const ShowContent = <Model extends ResourceModel>(props: Props<Model>) => {
-  const { showConfig, formatter, Dropdown = K8sDropdown } = props;
+  const { showConfig, formatter, Dropdown = K8sDropdown, children, canCollapseTabs } = props;
   const parsed = useParsed();
   const { resource } = useResource();
   const id = parsed?.params?.id;
@@ -22,6 +21,9 @@ export const ShowContent = <Model extends ResourceModel>(props: Props<Model>) =>
       showConfig={showConfig}
       formatter={formatter}
       Dropdown={Dropdown}
-    />
+      canCollapseTabs={canCollapseTabs}
+    >
+      {children}
+    </ShowContentView>
   );
 };

--- a/packages/refine/src/components/ShowContent/ShowContentView.tsx
+++ b/packages/refine/src/components/ShowContent/ShowContentView.tsx
@@ -9,13 +9,15 @@ import {
   Button,
 } from '@cloudtower/eagle';
 import {
+  ArrowChevronDown16OntintIcon,
   ArrowChevronLeft16BoldTertiaryIcon,
   ArrowChevronLeftSmall16BoldBlueIcon,
+  ArrowChevronUp16OntintIcon,
 } from '@cloudtower/icons-react';
 import { css, cx } from '@linaria/core';
 import { useShow, useNavigation, useGo, CanAccess } from '@refinedev/core';
 import { get } from 'lodash-es';
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import K8sDropdown from 'src/components/Dropdowns/K8sDropdown';
 import { Tabs as BaseTabs } from 'src/components/Tabs';
@@ -149,6 +151,7 @@ export type ShowContentViewProps<Model extends ResourceModel> = {
   formatter?: (r: Model) => Model;
   Dropdown?: React.FC<{ record: Model }>;
   hideBackButton?: boolean;
+  canCollapseTabs?: boolean;
 };
 
 type ShowGroupComponentProps = React.PropsWithChildren<{
@@ -181,6 +184,7 @@ export const ShowContentView = <Model extends ResourceModel>(
     formatter,
     Dropdown = K8sDropdown,
     hideBackButton = false,
+    canCollapseTabs = false,
   } = props;
   const { queryResult } = useShow<Model>({
     id,
@@ -370,7 +374,37 @@ export const ShowContentView = <Model extends ResourceModel>(
         {topBar}
       </Space>
       {basicInfo}
-      {tabs}
+
+      {canCollapseTabs ? <CollapseTabs>{tabs}</CollapseTabs> : tabs}
     </div>
   );
+};
+
+const CollapseTabs: React.FC = props => {
+  const [isCollapsed, setIsCollapsed] = useState(true);
+  const { t } = useTranslation();
+  if (isCollapsed) {
+    return (
+      <Button
+        type='text'
+        onClick={() => setIsCollapsed(v => !v)}
+        suffixIcon={<Icon src={ArrowChevronUp16OntintIcon} />}
+      >
+        {t('dovetail.view_all_info')}
+      </Button>
+    );
+  } else {
+    return (
+      <>
+        {props.children}
+        <Button
+          type='text'
+          onClick={() => setIsCollapsed(v => !v)}
+          suffixIcon={<Icon src={ArrowChevronDown16OntintIcon} />}
+        >
+          {t('dovetail.collapse')}
+        </Button>
+      </>
+    );
+  }
 };

--- a/packages/refine/src/components/ShowContent/ShowContentView.tsx
+++ b/packages/refine/src/components/ShowContent/ShowContentView.tsx
@@ -7,6 +7,7 @@ import {
   Col,
   Row,
   Button,
+  Tag,
 } from '@cloudtower/eagle';
 import {
   ArrowChevronDown16OntintIcon,
@@ -142,6 +143,13 @@ const TabsStyle = css`
       }
     }
   }
+`;
+
+const KindTagStyle = css`
+  margin: auto 0;
+  margin-right: 8px;
+  border: 1px solid #acbad399;
+  background-color: white;
 `;
 
 export type ShowContentViewProps<Model extends ResourceModel> = {
@@ -312,6 +320,7 @@ export const ShowContentView = <Model extends ResourceModel>(
       )}
       <Space className={TopBarStyle}>
         <div style={{ display: 'flex' }}>
+          <Tag.NameTag className={KindTagStyle}>{config.kind}</Tag.NameTag>
           <span className={cx(Typo.Display.d2_regular_title, NameStyle)}>
             {showConfig.displayName?.(record) || record?.metadata?.name}
           </span>
@@ -386,7 +395,7 @@ const CollapseTabs: React.FC = props => {
   if (isCollapsed) {
     return (
       <Button
-        type='text'
+        type="text"
         onClick={() => setIsCollapsed(v => !v)}
         suffixIcon={<Icon src={ArrowChevronUp16OntintIcon} />}
       >
@@ -398,7 +407,7 @@ const CollapseTabs: React.FC = props => {
       <>
         {props.children}
         <Button
-          type='text'
+          type="text"
           onClick={() => setIsCollapsed(v => !v)}
           suffixIcon={<Icon src={ArrowChevronDown16OntintIcon} />}
         >

--- a/packages/refine/src/components/ShowContent/ShowContentView.tsx
+++ b/packages/refine/src/components/ShowContent/ShowContentView.tsx
@@ -10,10 +10,10 @@ import {
   Tag,
 } from '@cloudtower/eagle';
 import {
-  ArrowChevronDown16OntintIcon,
+  ArrowBoldDown16Icon,
   ArrowChevronLeft16BoldTertiaryIcon,
   ArrowChevronLeftSmall16BoldBlueIcon,
-  ArrowChevronUp16OntintIcon,
+  ArrowChevronUp16BoldSecondaryIcon,
 } from '@cloudtower/icons-react';
 import { css, cx } from '@linaria/core';
 import { useShow, useNavigation, useGo, CanAccess } from '@refinedev/core';
@@ -95,6 +95,13 @@ const GroupStyle = css`
     padding-bottom: 0;
   }
 `;
+
+const BasicGroupStyle = css`
+  margin: 0 24px;
+  overflow: auto;
+  margin-bottom: 16;
+`;
+
 const GroupTitleStyle = css`
   display: flex;
   color: $blue-100;
@@ -152,7 +159,7 @@ const KindTagStyle = css`
   background-color: white;
 `;
 
-export type ShowContentViewProps<Model extends ResourceModel> = {
+export type ShowContentViewProps<Model extends ResourceModel> = React.PropsWithChildren<{
   id: string;
   resourceName: string;
   showConfig: ShowConfig<Model>;
@@ -160,7 +167,7 @@ export type ShowContentViewProps<Model extends ResourceModel> = {
   Dropdown?: React.FC<{ record: Model }>;
   hideBackButton?: boolean;
   canCollapseTabs?: boolean;
-};
+}>;
 
 type ShowGroupComponentProps = React.PropsWithChildren<{
   title: string;
@@ -182,6 +189,12 @@ export function ShowGroupComponent(props: ShowGroupComponentProps) {
   );
 }
 
+export function BasicShowGroupComponent(props: React.PropsWithChildren<unknown>) {
+  const { children } = props;
+
+  return <div className={BasicGroupStyle}>{children}</div>;
+}
+
 export const ShowContentView = <Model extends ResourceModel>(
   props: ShowContentViewProps<Model>
 ) => {
@@ -190,6 +203,7 @@ export const ShowContentView = <Model extends ResourceModel>(
     resourceName,
     showConfig,
     formatter,
+    children,
     Dropdown = K8sDropdown,
     hideBackButton = false,
     canCollapseTabs = false,
@@ -272,8 +286,14 @@ export const ShowContentView = <Model extends ResourceModel>(
     });
   }
 
-  function renderGroup(group: ShowGroup<Model>) {
-    const GroupContainer = group.title ? ShowGroupComponent : React.Fragment;
+  function renderGroup(group: ShowGroup<Model>, isBasicGroup = false) {
+    let GroupContainer: React.FC<ShowGroupComponentProps> = React.Fragment;
+    if (isBasicGroup) {
+      GroupContainer = BasicShowGroupComponent;
+    } else if (group.title) {
+      GroupContainer = ShowGroupComponent;
+    }
+
     const FieldContainer = group.title ? Row : React.Fragment;
     const groupContainerProps = group.title ? { title: group.title || '' } : {};
     const fieldContainerProps = group.title ? { gutter: [24, 8] } : {};
@@ -366,7 +386,7 @@ export const ShowContentView = <Model extends ResourceModel>(
                 tab.groups.length <= 1 && tabIndex !== 0 && FullTabContentStyle
               )}
             >
-              {tab.groups?.map(renderGroup)}
+              {tab.groups?.map(group => renderGroup(group, false))}
             </div>
           ),
         };
@@ -375,7 +395,9 @@ export const ShowContentView = <Model extends ResourceModel>(
     />
   );
 
-  const basicInfo = showConfig.basicGroup ? renderGroup(showConfig.basicGroup) : null;
+  const basicInfo = showConfig.basicGroup
+    ? renderGroup(showConfig.basicGroup, true)
+    : null;
 
   return (
     <div className={ShowContentWrapperStyle}>
@@ -385,6 +407,7 @@ export const ShowContentView = <Model extends ResourceModel>(
       {basicInfo}
 
       {canCollapseTabs ? <CollapseTabs>{tabs}</CollapseTabs> : tabs}
+      {children}
     </div>
   );
 };
@@ -394,25 +417,31 @@ const CollapseTabs: React.FC = props => {
   const { t } = useTranslation();
   if (isCollapsed) {
     return (
-      <Button
-        type="text"
-        onClick={() => setIsCollapsed(v => !v)}
-        suffixIcon={<Icon src={ArrowChevronUp16OntintIcon} />}
-      >
-        {t('dovetail.view_all_info')}
-      </Button>
+      <div style={{ display: 'flex' }}>
+        <Button
+          style={{ margin: 'auto', cursor: 'pointer' }}
+          type="quiet"
+          onClick={() => setIsCollapsed(v => !v)}
+          suffixIcon={<Icon src={ArrowChevronUp16BoldSecondaryIcon} />}
+        >
+          {t('dovetail.view_all_info')}
+        </Button>
+      </div>
     );
   } else {
     return (
       <>
         {props.children}
-        <Button
-          type="text"
-          onClick={() => setIsCollapsed(v => !v)}
-          suffixIcon={<Icon src={ArrowChevronDown16OntintIcon} />}
-        >
-          {t('dovetail.collapse')}
-        </Button>
+        <div style={{ display: 'flex' }}>
+          <Button
+            style={{ margin: 'auto', cursor: 'pointer' }}
+            type="quiet"
+            onClick={() => setIsCollapsed(v => !v)}
+            suffixIcon={<Icon src={ArrowBoldDown16Icon} />}
+          >
+            {t('dovetail.collapse')}
+          </Button>
+        </div>
       </>
     );
   }

--- a/packages/refine/src/components/ShowContent/tabs.tsx
+++ b/packages/refine/src/components/ShowContent/tabs.tsx
@@ -26,7 +26,7 @@ export const EventsTab = <Model extends ResourceModel>(
   ],
 });
 
-export const PodLogTab = <Model extends PodModel>(i18n: I18nType): ShowTab<Model> => ({
+export const PodLogTab = <Model extends PodModel>(i18n: I18nType, apiUrl: string): ShowTab<Model> => ({
   title: i18n.t('dovetail.log'),
   key: 'pod-log',
   groups: [
@@ -38,7 +38,7 @@ export const PodLogTab = <Model extends PodModel>(i18n: I18nType): ShowTab<Model
               key: 'log',
               path: [],
               renderContent: (_, record) => {
-                return <PodLog pod={record} />;
+                return <PodLog pod={record} apiUrl={apiUrl} />;
               },
             },
           ],

--- a/packages/refine/src/locales/zh-CN/dovetail.json
+++ b/packages/refine/src/locales/zh-CN/dovetail.json
@@ -240,5 +240,7 @@
   "cant_delete_resource": "无法删除{{resource}}",
   "cant_delete_resource_with_name": "无法删除{{resource}} <0>{{name}}</0> 。",
   "close": "关闭",
-  "import_from_file": "从文件读取"
+  "import_from_file": "从文件读取",
+  "view_all_info": "查看全部信息",
+  "collapse": "收起"
 }

--- a/packages/refine/src/pages/pods/show/index.tsx
+++ b/packages/refine/src/pages/pods/show/index.tsx
@@ -1,4 +1,4 @@
-import { IResourceComponentsProps } from '@refinedev/core';
+import { IResourceComponentsProps, useDataProvider } from '@refinedev/core';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { PodDropdown } from 'src/components/Dropdowns/PodDropdown';
@@ -8,7 +8,9 @@ import { PodModel } from '../../../models';
 
 export const PodShow: React.FC<IResourceComponentsProps> = () => {
   const { i18n } = useTranslation();
-
+  const dataProvider = useDataProvider();
+  const apiUrl = dataProvider()['getApiUrl']();
+  
   return (
     <PageShow<PodModel>
       showConfig={{
@@ -46,7 +48,7 @@ export const PodShow: React.FC<IResourceComponentsProps> = () => {
             ],
           },
           EventsTab(i18n),
-          PodLogTab(i18n),
+          PodLogTab(i18n, apiUrl),
         ],
       }}
       Dropdown={PodDropdown}


### PR DESCRIPTION
1. 给ShowContent添加收起tab的功能
<img width="910" height="372" alt="截屏2025-08-19 14 08 24" src="https://github.com/user-attachments/assets/9b345da6-8889-41d5-b69e-1d534fa311c1" />
2. 给资源标题左边添加kind的标签
<img width="551" height="132" alt="截屏2025-08-19 14 09 02" src="https://github.com/user-attachments/assets/9eeb43c4-a6b4-4463-9c93-f0c0b2b5c457" />
3. PodLog组件的apiUrl 参数改成从外部传入，因为在弹窗中PodLog无法获取到Context