### PR TITLE
fix: edit form cannot autofill custom fields

### DIFF
--- a/packages/refine/src/components/Form/useReactHookForm.tsx
+++ b/packages/refine/src/components/Form/useReactHookForm.tsx
@@ -207,9 +207,9 @@ export const useForm = <
 
     /**
      * get registered fields from react-hook-form
-     */
-    const registeredFields = Object.keys(flattenObjectKeys(getValues()));
+     */ 
     const transformedData = transformInitValues ? transformInitValues(data) : data;
+    const registeredFields = Object.keys(flattenObjectKeys(transformedData));
 
     /**
      * set values from query result as default values
@@ -225,7 +225,7 @@ export const useForm = <
         setValue(path as Path<TVariables>, dataValue);
       }
     });
-  }, [queryResult?.data, setValue, getValues, transformInitValues, formState.isDirty]);
+  }, [queryResult?.data, setValue, transformInitValues, formState.isDirty]);
 
   useEffect(() => {
     const subscription = watch((values: any, { type }: { type?: any }) => {


### PR DESCRIPTION
registeredFields 来自于 getValue。但是当编辑表单的时候，要给表单填入资源的值的时候，getValue从表单获取到的还是空白的默认值，虽然也是经过transformInitValues的。但是如果transformInitValues中有一些需要条件判断的、默认值中不会添加的值，那么getValue的时候就获取不到，所以就不会被算在registeredFields中。所以不会不会被填入表单中。

解决办法是，根据transformedData来生成registeredFields，是最准确的。
