### PR TITLE
fix: pass resource name to openForm in k8sDropdown

### DIFF
--- a/packages/refine/src/components/Dropdowns/K8sDropdown/index.tsx
+++ b/packages/refine/src/components/Dropdowns/K8sDropdown/index.tsx
@@ -61,7 +61,7 @@ export function K8sDropdown(props: React.PropsWithChildren<K8sDropdownProps>) {
         overlay={
           <Menu>
             {isInShowPage || canEditData?.can === false || config.hideEdit ? null : (
-              <Menu.Item onClick={() => openForm({ id: record.id })}>
+              <Menu.Item onClick={() => openForm({ id: record.id, resourceName })}>
                 <Icon src={EditPen16PrimaryIcon}>
                   {formType === FormType.FORM
                     ? t('dovetail.edit')


### PR DESCRIPTION
k8sDropdown中的openForm需要传递resourceName，因为有的时候无法从url获取到资源名称