### PR TITLE
SKS-4407 fix: hide duplicate edit items in K8sDropdown on show pages

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.3.29-alpha.3",
+  "version": "0.3.30-alpha.1",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/src/components/Dropdowns/K8sDropdown/index.tsx
+++ b/packages/refine/src/components/Dropdowns/K8sDropdown/index.tsx
@@ -14,7 +14,7 @@ import {
   TrashBinDelete16Icon,
   Download16GradientBlueIcon,
 } from '@cloudtower/icons-react';
-import { useCan } from '@refinedev/core';
+import { useCan, useParsed, useResource } from '@refinedev/core';
 import { omit } from 'lodash-es';
 import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -102,12 +102,29 @@ export function K8sDropdown(props: React.PropsWithChildren<K8sDropdownProps>) {
   });
   const formType = config?.formConfig?.formType;
 
+  // 在详情页（show page）中，ShowContentView 已经渲染了独立的编辑按钮，
+  // 因此 Dropdown 中的编辑项需要根据情况隐藏以避免重复。
+  // 通过比较 Dropdown 操作的资源与当前页面资源，确保只在操作同一资源时隐藏，
+  // 这样 AccessMethodForm 等子资源表格中的 Dropdown 不会受影响。
+  const { action } = useParsed();
+  const { resource } = useResource();
+  const isInShowPage = action === 'show';
+  const isSameResource = resourceName === resource?.name;
+  const isShowPageSameResource = isInShowPage && isSameResource;
+
+  // Item 1（"编辑{Kind}" 或 "编辑 YAML"）：详情页且同资源时隐藏，因为与独立按钮完全重复
+  const shouldHideEdit = hideEditProp || isShowPageSameResource;
+  // Item 2（"编辑 YAML"）：当 formType 不是 FORM 时隐藏，
+  // 因为此时 Item 1 已经是"编辑 YAML"，两者文案和功能完全重复。
+  // 当 formType 是 FORM 时保留，因为它提供了与 Item 1（"编辑{Kind}"）不同的操作。
+  const shouldHideEditYaml = hideEditYaml || formType !== FormType.FORM;
+
   return (
     <>
       <Dropdown
         overlay={
           <Menu>
-            {hideEditProp || canEditData?.can === false || config?.hideEdit ? null : (
+            {shouldHideEdit || canEditData?.can === false || config?.hideEdit ? null : (
               <Menu.Item
                 onClick={() =>
                   openForm({ id: record.id, resourceName, resourceConfig: config })
@@ -123,7 +140,9 @@ export function K8sDropdown(props: React.PropsWithChildren<K8sDropdownProps>) {
                 </Icon>
               </Menu.Item>
             )}
-            {hideEditYaml || canEditData?.can === false || config?.hideEdit ? null : (
+            {shouldHideEditYaml ||
+            canEditData?.can === false ||
+            config?.hideEdit ? null : (
               <Menu.Item
                 onClick={() =>
                   openForm({
@@ -148,7 +167,9 @@ export function K8sDropdown(props: React.PropsWithChildren<K8sDropdownProps>) {
                   }
                 }}
               >
-                <Icon src={Download16GradientBlueIcon}>{t('dovetail.download_yaml')}</Icon>
+                <Icon src={Download16GradientBlueIcon}>
+                  {t('dovetail.download_yaml')}
+                </Icon>
               </Menu.Item>
             )}
             {props.children}


### PR DESCRIPTION
## Summary

- 详情页（show page）中 `ShowContentView` 已渲染独立编辑按钮，但 `K8sDropdown` 的下拉菜单中仍展示重复的编辑项
- 修改 `K8sDropdown`，自动隐藏重复的编辑菜单项
- 通过比较 `resourceName` 与 `resource.name`，确保 AccessMethodForm 等子资源表格的 Dropdown 不受影响

## Changes

在 `K8sDropdown` 中新增逻辑：
- 使用 `useParsed()` 检测 `action === 'show'`
- 使用 `useResource()` 比较 Dropdown 操作的资源与当前页面资源
- **Item 1**（编辑{Kind}/编辑 YAML）：详情页且同资源时隐藏（与独立按钮重复）
- **Item 2**（编辑 YAML）：当 `formType !== FormType.FORM` 时始终隐藏（非 FORM 资源的 Item 1 已经是"编辑 YAML"，两者文案和功能完全重复）；FORM 类资源保留（提供与 Item 1 "编辑{Kind}" 不同的操作）

## Affected Resources

| 类型 | 资源 | 列表页行为 | 详情页行为 |
|------|------|----------|----------|
| FORM 类 | Deployment, DaemonSet, StatefulSet, Job, CronJob, ConfigMap, Secret, Service, Ingress | 编辑{Kind} + 编辑 YAML + 其他 | 隐藏"编辑{Kind}"，保留"编辑 YAML" |
| YAML 类 | PV, IngressClass | 编辑 YAML + 其他（去重后只一个） | 隐藏全部编辑项（独立按钮已是"编辑 YAML"） |
| hideEdit | Pod, StorageClass, PVC, Node... | 不受影响 | 不受影响（编辑已全局隐藏） |
| 子资源 | AccessMethodForm 中的 Service/Ingress | 不受影响 | 不受影响（resourceName 不匹配） |

## Test plan

- [ ] FORM 类资源详情页：独立按钮"编辑{Kind}" + Dropdown 无"编辑{Kind}"、有"编辑 YAML"
- [ ] FORM 类资源列表页：Dropdown 有"编辑{Kind}" + "编辑 YAML"
- [ ] YAML 类资源详情页：独立按钮"编辑 YAML" + Dropdown 无编辑项
- [ ] YAML 类资源列表页：Dropdown 只有一个"编辑 YAML"（不再重复）
- [ ] 工作负载详情页 AccessMethodForm：Service/Ingress 行 Dropdown 编辑操作保留
- [ ] CronJob 详情页 Job 子资源：isCronjobChild 逻辑不受影响

## Test result

<img width="1778" height="1026" alt="image" src="https://github.com/user-attachments/assets/45546b69-cea7-40ca-a76a-f0da2e64adca" />

<img width="1775" height="1024" alt="image" src="https://github.com/user-attachments/assets/a338bf68-0e0e-4022-93cb-400c0969f90d" />

<img width="1776" height="1020" alt="image" src="https://github.com/user-attachments/assets/7765777a-ed28-407d-beb6-6dbeb0588b70" />

<img width="1776" height="1027" alt="image" src="https://github.com/user-attachments/assets/21d4c93f-c14f-4422-b618-6e9487d59ca2" />

<img width="1290" height="554" alt="image" src="https://github.com/user-attachments/assets/28f5aacf-e934-46e1-bc02-7673b983aca5" />

<img width="1286" height="527" alt="image" src="https://github.com/user-attachments/assets/0a261a8f-652b-4228-b252-74d49ad1ae60" />

