### PR TITLE
fix: suppress expire dialogs during submit

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.3.30-alpha.1",
+  "version": "0.3.30",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/src/components/Form/RefineFormContainer.tsx
+++ b/packages/refine/src/components/Form/RefineFormContainer.tsx
@@ -1,7 +1,7 @@
 import { Alert, Loading, usePushModal, usePopModal } from '@cloudtower/eagle';
 import { BaseRecord, CreateResponse, UpdateResponse } from '@refinedev/core';
 import { Unstructured } from 'k8s-api-provider';
-import React, { useMemo, useEffect, useImperativeHandle, useRef } from 'react';
+import React, { useMemo, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { type SaveButtonProps } from 'src/components/Form/FormModal';
 import usePathMap from 'src/hooks/usePathMap';
 import { useResourceVersionCheck } from 'src/hooks/useResourceVersionCheck';
@@ -59,6 +59,7 @@ const RefineFormContainer = React.forwardRef<
   const pushModal = usePushModal();
   const popModal = usePopModal();
   const hasShownExpiredRef = useRef(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const refineFormResult = useRefineForm({
     resourceConfig: resourceConfig,
@@ -68,6 +69,7 @@ const RefineFormContainer = React.forwardRef<
         onSuccess?.(data);
       },
       onMutationError() {
+        setIsSubmitting(false);
         onError?.();
       },
       redirect: false,
@@ -81,8 +83,15 @@ const RefineFormContainer = React.forwardRef<
       ...options,
       onBeforeSubmitError: (errors: string[]) => {
         if (errors.length) {
+          setIsSubmitting(false);
           onError?.();
         }
+      },
+      onSubmitStart: () => {
+        setIsSubmitting(true);
+      },
+      onSubmitAbort: () => {
+        setIsSubmitting(false);
       },
     },
   });
@@ -91,18 +100,20 @@ const RefineFormContainer = React.forwardRef<
   });
 
   useEffect(() => {
-    if (isExpired && !hasShownExpiredRef.current) {
-      hasShownExpiredRef.current = true;
-      pushModal<'DataExpiredModal'>({
-        component: DataExpiredModal,
-        props: {
-          onAbandon: () => {
-            popModal();
-          },
-        },
-      });
+    if (!isExpired || isSubmitting || hasShownExpiredRef.current) {
+      return;
     }
-  }, [isExpired, pushModal, popModal]);
+
+    hasShownExpiredRef.current = true;
+    pushModal<'DataExpiredModal'>({
+      component: DataExpiredModal,
+      props: {
+        onAbandon: () => {
+          popModal();
+        },
+      },
+    });
+  }, [isExpired, isSubmitting, pushModal, popModal]);
 
   const fieldsConfig = useFieldsConfig(
     resourceConfig,
@@ -138,6 +149,12 @@ const RefineFormContainer = React.forwardRef<
         isShowLayout: false,
         useFormProps: {
           redirect: false,
+          onSubmitStart: () => {
+            setIsSubmitting(true);
+          },
+          onSubmitAbort: () => {
+            setIsSubmitting(false);
+          },
         },
         rules: fieldsConfig
           ?.filter(

--- a/packages/refine/src/components/Form/YamlFormContainer.tsx
+++ b/packages/refine/src/components/Form/YamlFormContainer.tsx
@@ -1,7 +1,7 @@
 import { usePushModal, usePopModal } from '@cloudtower/eagle';
 import { BaseRecord, CreateResponse, UpdateResponse, useOne } from '@refinedev/core';
 import { Unstructured } from 'k8s-api-provider';
-import React, { useMemo, useEffect, useRef } from 'react';
+import React, { useMemo, useEffect, useRef, useState } from 'react';
 import { type SaveButtonProps } from 'src/components/Form/FormModal';
 import usePathMap from 'src/hooks/usePathMap';
 import { useResourceVersionCheck } from 'src/hooks/useResourceVersionCheck';
@@ -46,6 +46,7 @@ function YamlFormContainer({
   const pushModal = usePushModal();
   const popModal = usePopModal();
   const hasShownExpiredRef = useRef(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const queryResult = useOne({
     resource: resourceConfig.name,
@@ -57,18 +58,20 @@ function YamlFormContainer({
   const isExpired = useResourceVersionCheck({ queryResult });
 
   useEffect(() => {
-    if (isExpired && !hasShownExpiredRef.current) {
-      hasShownExpiredRef.current = true;
-      pushModal<'DataExpiredModal'>({
-        component: DataExpiredModal,
-        props: {
-          onAbandon: () => {
-            popModal();
-          },
-        },
-      });
+    if (!isExpired || isSubmitting || hasShownExpiredRef.current) {
+      return;
     }
-  }, [isExpired, pushModal, popModal]);
+
+    hasShownExpiredRef.current = true;
+    pushModal<'DataExpiredModal'>({
+      component: DataExpiredModal,
+      props: {
+        onAbandon: () => {
+          popModal();
+        },
+      },
+    });
+  }, [isExpired, isSubmitting, pushModal, popModal]);
 
   const { transformInitValues, transformApplyValues } = usePathMap({
     pathMap: formConfig?.pathMap,
@@ -93,6 +96,12 @@ function YamlFormContainer({
       isShowLayout: false,
       useFormProps: {
         redirect: false,
+        onSubmitStart: () => {
+          setIsSubmitting(true);
+        },
+        onSubmitAbort: () => {
+          setIsSubmitting(false);
+        },
       },
       rules: undefined,
       onSaveButtonPropsChange,

--- a/packages/refine/src/components/Form/useReactHookForm.tsx
+++ b/packages/refine/src/components/Form/useReactHookForm.tsx
@@ -88,6 +88,8 @@ export type UseFormProps<
     setErrors: (errors: string[]) => void
   ) => Promise<TVariables>;
   onBeforeSubmitError?: (errors: string[]) => void;
+  onSubmitStart?: () => void;
+  onSubmitAbort?: () => void;
 } & UseHookFormProps<TVariables, TContext>;
 
 export const useForm = <
@@ -106,6 +108,8 @@ export const useForm = <
   transformInitValues,
   beforeSubmit,
   onBeforeSubmitError,
+  onSubmitStart,
+  onSubmitAbort,
   ...rest
 }: UseFormProps<
   TQueryFnData,
@@ -295,6 +299,7 @@ export const useForm = <
       onClick: async (e: React.BaseSyntheticEvent) => {
         // 清空之前的错误
         setBeforeSubmitErrors([]);
+        onSubmitStart?.();
 
         handleSubmit(
           async v => {
@@ -315,6 +320,7 @@ export const useForm = <
 
                 // 如果有错误，则不继续提交
                 if (hasErrors) {
+                  onSubmitAbort?.();
                   return;
                 }
 
@@ -322,6 +328,9 @@ export const useForm = <
                 if (result !== undefined) {
                   finalValues = result as TVariables;
                 }
+              } catch (error) {
+                onSubmitAbort?.();
+                throw error;
               } finally {
                 setIsBeforeSubmitLoading(false);
               }
@@ -329,7 +338,10 @@ export const useForm = <
 
             return onFinish(finalValues);
           },
-          () => false
+          () => {
+            onSubmitAbort?.();
+            return false;
+          }
         )(e);
       },
     };
@@ -341,6 +353,8 @@ export const useForm = <
     transformApplyValues,
     beforeSubmit,
     onBeforeSubmitError,
+    onSubmitStart,
+    onSubmitAbort,
   ]);
 
   return {

--- a/packages/refine/src/components/Form/useRefineForm.ts
+++ b/packages/refine/src/components/Form/useRefineForm.ts
@@ -15,6 +15,8 @@ import { useForm, UseFormProps } from './useReactHookForm';
 interface UseRefineFormOptions {
   initialValues?: Record<string, unknown>;
   onBeforeSubmitError?: (errors: string[]) => void;
+  onSubmitStart?: () => void;
+  onSubmitAbort?: () => void;
 }
 
 export const useRefineForm = (props: {
@@ -69,6 +71,8 @@ export const useRefineForm = (props: {
     transformInitValues,
     beforeSubmit: formConfig?.beforeSubmit,
     onBeforeSubmitError: options?.onBeforeSubmitError,
+    onSubmitStart: options?.onSubmitStart,
+    onSubmitAbort: options?.onSubmitAbort,
     ...formConfig?.useFormProps,
   });
 

--- a/packages/refine/src/components/Form/useYamlForm.ts
+++ b/packages/refine/src/components/Form/useYamlForm.ts
@@ -68,6 +68,8 @@ export type UseFormProps<
   transformApplyValues?: (values: Unstructured) => Unstructured;
   beforeSubmit?: (values: Unstructured, setErrors: (errors: string[]) => void) => Promise<Unstructured>;
   onBeforeSubmitError?: (errors: string[]) => void;
+  onSubmitStart?: () => void;
+  onSubmitAbort?: () => void;
   rules?: YamlFormRule[];
 };
 
@@ -146,6 +148,8 @@ const useYamlForm = <
   transformApplyValues,
   beforeSubmit,
   onBeforeSubmitError,
+  onSubmitStart,
+  onSubmitAbort,
   rules,
 }: UseFormProps<
   TQueryFnData,
@@ -202,6 +206,7 @@ const useYamlForm = <
   >({
     onMutationSuccess: onMutationSuccessProp ? onMutationSuccessProp : undefined,
     onMutationError: (error, ...restParams) => {
+      onSubmitAbort?.();
       const response = error.response;
 
       if (response && !response?.bodyUsed) {
@@ -361,6 +366,7 @@ const useYamlForm = <
       onFinish: async (values) => {
         // 清空之前的错误
         setBeforeSubmitErrors([]);
+        onSubmitStart?.();
 
         const errors = [
           !isYamlValid ? t('dovetail.yaml_format_wrong') : '',
@@ -368,6 +374,7 @@ const useYamlForm = <
         ].filter(error => !!error);
 
         if (errors.length) {
+          onSubmitAbort?.();
           setEditorErrors(errors);
           setRulesErrors([]);
           return;
@@ -376,6 +383,7 @@ const useYamlForm = <
         const rulesErrors = await validateRules(editor.current?.getEditorValue() || '');
 
         if (Object.keys(rulesErrors).length) {
+          onSubmitAbort?.();
           setRulesErrors(Object.values(rulesErrors));
           return;
         }
@@ -403,6 +411,7 @@ const useYamlForm = <
 
               // 如果有错误，则不继续提交
               if (hasErrors) {
+                onSubmitAbort?.();
                 return;
               }
 
@@ -417,6 +426,7 @@ const useYamlForm = <
 
           return onFinish(finalValues as TVariables);
         } catch (error: unknown) {
+          onSubmitAbort?.();
           if (error instanceof Error) {
             if (
               error.message === 'expected a single document in the stream, but found more'


### PR DESCRIPTION
## 背景

http://jira.smartx.com/browse/SKS-4607

表单 - 编辑表单时保存成功后，未退出编辑页面

因为之前添加了根据revision判断表单是否过期的弹窗。但是在编辑完表单的一刹那，revision更新了，但表单弹窗还没有关闭，所以弹出了过期的警告弹窗，但是此时又触发了编辑成功的popModal动作，所以过期弹窗被关闭了，结果就是看起来保存成功了，但是表单没有关闭。

## 概要
- 在表单提交进行中抑制 expire 弹窗
- 为结构化表单和 YAML 表单接入统一的提交生命周期回调
- 避免因为刻意 suppress 而提前消费一次性 expire 标记

## 校验
- `git diff --check`

## 备注
- 本次提交未包含本地 `packages/refine/package.json` 中的 yalc / self-dependency 改动