### PR TITLE
SKS-4403 fix YAML editor schema completion for workload resources

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/src/components/Form/useYamlForm.ts
+++ b/packages/refine/src/components/Form/useYamlForm.ts
@@ -289,7 +289,7 @@ const useYamlForm = <
           ? generateYamlBySchema(initialValues || {}, schema)
           : yaml.dump(initialValues),
       schemas: schemas || emptySchemas,
-      id: useResourceResult.resource?.name || '',
+      id: resource || useResourceResult.resource?.name || '',
       errorMsgs: finalErrors,
       onValidate(yamlValid: boolean, schemaValid: boolean) {
         setIsYamlValid(yamlValid);
@@ -315,6 +315,7 @@ const useYamlForm = <
     editorOptions?.isGenerateAnnotations,
     initialValues,
     schemas,
+    resource,
     useResourceResult.resource?.name,
     action,
     finalErrors,


### PR DESCRIPTION
## Summary

- Fix YAML editor schema completion not working for workload resources (Deployment, StatefulSet, DaemonSet, CronJob, etc.)
- Root cause: `useYamlForm` derived the Monaco editor `id` from `useResource()` (route-based), which returned `undefined` when on a resource group route like `/workloads`. This caused `fileMatch: ["undefined"]` which never matched the editor model URI.
- Fix: prefer the `resource` prop (e.g. `"deployments"`) over the route-based resource name for the editor `id`

## Test plan

- [x] Open a workload cluster → Deployments → Create → switch to YAML mode → verify schema completion works (e.g. `imagePullPolicy` suggests `Always`/`IfNotPresent`/`Never`)
- [x] Open Service → Create → switch to YAML mode → verify schema completion still works (regression check)
- [x] Open ConfigMap → Create → switch to YAML mode → verify schema completion still works (regression check)
- [x] Open Deployment edit (Edit YAML) → verify schema completion works