### PR TITLE
Fix/pod log

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -13,7 +13,7 @@
     "@cloudtower/eagle": "^490.0.1",
     "@cloudtower/icons-react": "^490.0.1",
     "@patternfly/react-core": "^5.1.1",
-    "@patternfly/react-log-viewer": "^5.0.0",
+    "@patternfly/react-log-viewer": "^5.2.0",
     "@refinedev/core": "^4.47.2",
     "@refinedev/inferencer": "^4.5.20",
     "@refinedev/react-hook-form": "^4.8.14",

--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.3.33",
+  "version": "0.4.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/src/components/PodLog/index.tsx
+++ b/packages/refine/src/components/PodLog/index.tsx
@@ -37,7 +37,7 @@ const ContentStyle = css`
   min-height: 0;
 `;
 
-export const PodLog: React.FC<{ pod: PodModel, apiUrl: string }> = ({ pod, apiUrl }) => {
+export const PodLog: React.FC<{ pod: PodModel; apiUrl: string }> = ({ pod, apiUrl }) => {
   const [selectedContainer, setSelectedContainer] = useState(
     pod.spec?.containers[0]?.name || ''
   );
@@ -249,6 +249,7 @@ export const PodLog: React.FC<{ pod: PodModel, apiUrl: string }> = ({ pod, apiUr
             theme="light"
             isTextWrapped={wrap}
             onScroll={onScroll}
+            fastRowHeightEstimationLimit={100}
           />
         )}
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,10 +2712,10 @@
   resolved "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.1.1.tgz#be1249e2f3abdc0e280952f88c3d5deb07fe1dde"
   integrity sha512-9gCxkWz2xcdi0rtXu2F0L68w4tLIlsgGTACo1ggr4aVng9jRX++o1PlCOqscOd9o0NiFnFD7BLlZUGvJWaYEZg==
 
-"@patternfly/react-log-viewer@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/@patternfly/react-log-viewer/-/react-log-viewer-5.0.0.tgz#be41ceed8bd8f1761a8ad8184ffbb62a4633e6c9"
-  integrity sha512-N4E1HAfXVlPDsvCvXhh7ycO/pu8h7nGBjQgGV7mUWQb23Q8djuzPU3aK/QODVEP6ZCnlvq2AbaKUpaLiE5z4ww==
+"@patternfly/react-log-viewer@^5.2.0":
+  version "5.3.0"
+  resolved "https://registry.npmmirror.com/@patternfly/react-log-viewer/-/react-log-viewer-5.3.0.tgz#4df3344d0983c45a1a23ce237d4faa5d7285ece0"
+  integrity sha512-6jzhxwJwllLdX3jpoGdzIhvhPTfYuC6B+KuN2Laf7Iuioeig8bOMzJZFh6VXg+aBGd9j4JGv2dYryDsbDsTLvw==
   dependencies:
     "@patternfly/react-core" "^5.0.0"
     "@patternfly/react-icons" "^5.0.0"


### PR DESCRIPTION
修复某些情况下 Pod 日志文字重叠的问题。

LogViewer 的虚拟滚动不是精确计算高度的，需设置 fastRowHeightEstimationLimit，超出 100 个字符后改为精确计算高度。