### PR TITLE
feat: add formFailedText config for custom form failure message

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.3.33",
+  "version": "0.4.1",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -13,7 +13,7 @@
     "@cloudtower/eagle": "^490.0.1",
     "@cloudtower/icons-react": "^490.0.1",
     "@patternfly/react-core": "^5.1.1",
-    "@patternfly/react-log-viewer": "^5.0.0",
+    "@patternfly/react-log-viewer": "^5.2.0",
     "@refinedev/core": "^4.47.2",
     "@refinedev/inferencer": "^4.5.20",
     "@refinedev/react-hook-form": "^4.8.14",

--- a/packages/refine/src/components/Form/FormModal.tsx
+++ b/packages/refine/src/components/Form/FormModal.tsx
@@ -156,10 +156,12 @@ export function FormModal(props: FormModalProps) {
 
   const errorText = useMemo(() => {
     if (isError) {
+      const customText = resourceConfig.formConfig?.formFailedText;
+      if (customText) return customText;
       return i18n.t(id ? 'dovetail.save_failed' : 'dovetail.create_failed');
     }
     return '';
-  }, [isError, id, i18n]);
+  }, [isError, id, i18n, resourceConfig.formConfig?.formFailedText]);
   const title = useMemo(() => {
     if (typeof resourceConfig.formConfig?.formTitle === 'string')
       return resourceConfig.formConfig?.formTitle;

--- a/packages/refine/src/components/Form/RawYamlFormModal.tsx
+++ b/packages/refine/src/components/Form/RawYamlFormModal.tsx
@@ -53,10 +53,12 @@ export function RawYamlFormModal(props: RawYamlFormModalProps) {
 
   const errorText = useMemo(() => {
     if (isError) {
+      const customText = resourceConfig.formConfig?.formFailedText;
+      if (customText) return customText;
       return i18n.t(id ? 'dovetail.save_failed' : 'dovetail.create_failed');
     }
     return '';
-  }, [isError, id, i18n]);
+  }, [isError, id, i18n, resourceConfig.formConfig?.formFailedText]);
 
   const title = useMemo(() => {
     if (typeof resourceConfig.formConfig?.formTitle === 'string')

--- a/packages/refine/src/components/PodLog/index.tsx
+++ b/packages/refine/src/components/PodLog/index.tsx
@@ -37,7 +37,7 @@ const ContentStyle = css`
   min-height: 0;
 `;
 
-export const PodLog: React.FC<{ pod: PodModel, apiUrl: string }> = ({ pod, apiUrl }) => {
+export const PodLog: React.FC<{ pod: PodModel; apiUrl: string }> = ({ pod, apiUrl }) => {
   const [selectedContainer, setSelectedContainer] = useState(
     pod.spec?.containers[0]?.name || ''
   );
@@ -249,6 +249,7 @@ export const PodLog: React.FC<{ pod: PodModel, apiUrl: string }> = ({ pod, apiUr
             theme="light"
             isTextWrapped={wrap}
             onScroll={onScroll}
+            fastRowHeightEstimationLimit={100}
           />
         )}
       </div>

--- a/packages/refine/src/types/resource.ts
+++ b/packages/refine/src/types/resource.ts
@@ -142,6 +142,8 @@ export type CommonFormConfig<Model extends ResourceModel = ResourceModel> = {
   formDesc?: string | ((action: 'create' | 'edit') => string);
   /** 保存按钮文本 */
   saveButtonText?: string;
+  /** 提交失败时 Footer 的提示文本，如"克隆失败" */
+  formFailedText?: string;
   /**
    * 错误信息格式化函数，待完善
    * @param errorBody 错误信息体

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,10 +2712,10 @@
   resolved "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.1.1.tgz#be1249e2f3abdc0e280952f88c3d5deb07fe1dde"
   integrity sha512-9gCxkWz2xcdi0rtXu2F0L68w4tLIlsgGTACo1ggr4aVng9jRX++o1PlCOqscOd9o0NiFnFD7BLlZUGvJWaYEZg==
 
-"@patternfly/react-log-viewer@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/@patternfly/react-log-viewer/-/react-log-viewer-5.0.0.tgz#be41ceed8bd8f1761a8ad8184ffbb62a4633e6c9"
-  integrity sha512-N4E1HAfXVlPDsvCvXhh7ycO/pu8h7nGBjQgGV7mUWQb23Q8djuzPU3aK/QODVEP6ZCnlvq2AbaKUpaLiE5z4ww==
+"@patternfly/react-log-viewer@^5.2.0":
+  version "5.3.0"
+  resolved "https://registry.npmmirror.com/@patternfly/react-log-viewer/-/react-log-viewer-5.3.0.tgz#4df3344d0983c45a1a23ce237d4faa5d7285ece0"
+  integrity sha512-6jzhxwJwllLdX3jpoGdzIhvhPTfYuC6B+KuN2Laf7Iuioeig8bOMzJZFh6VXg+aBGd9j4JGv2dYryDsbDsTLvw==
   dependencies:
     "@patternfly/react-core" "^5.0.0"
     "@patternfly/react-icons" "^5.0.0"


### PR DESCRIPTION
## Summary

- `CommonFormConfig` 新增 `formFailedText?: string` 可选属性
- `FormModal` 和 `RawYamlFormModal` 的 footer 错误提示优先使用 `formFailedText`，未配置时回退到默认的 `dovetail.create_failed` / `dovetail.save_failed`
- 用于 SKS 克隆/恢复等场景，将默认的"创建失败。"替换为"克隆持久卷申领失败。"等自定义文案

## Test plan

- [ ] 配置 `formFailedText` 的表单提交失败时，footer 显示自定义文案
- [ ] 未配置 `formFailedText` 的表单行为不变，仍显示默认的"创建失败。"/"保存失败。"