### PR TITLE
feat: FormModal support extra submit button

### DIFF
--- a/packages/refine/src/components/Form/ExtraSubmitFooter.tsx
+++ b/packages/refine/src/components/Form/ExtraSubmitFooter.tsx
@@ -1,0 +1,201 @@
+import { Button, Typo } from '@cloudtower/eagle';
+import {
+  ArrowChevronLeft16BoldBlueIcon,
+  ExclamationErrorCircleFill16RedIcon,
+} from '@cloudtower/icons-react';
+import { css, cx } from '@linaria/core';
+import { omit } from 'lodash-es';
+import React, { useMemo } from 'react';
+import { RefineFormConfig } from 'src/types';
+import { type SaveButtonProps } from './FormModal';
+
+const FooterStyle = css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+`;
+const FooterLeftStyle = css`
+  display: flex;
+  align-items: center;
+  min-width: 0;
+`;
+const FooterRightStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+const ErrorStyle = css`
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  color: var(--color-red-6);
+`;
+const ErrorIconStyle = css`
+  flex: none;
+  margin-right: 4px;
+`;
+const PrevIconStyle = css`
+  margin-right: 4px;
+`;
+
+interface ExtraSubmitFooterProps {
+  cancelText: React.ReactNode;
+  errorText: React.ReactNode;
+  extraSubmitText: React.ReactNode;
+  nextStepText: React.ReactNode;
+  prevText: React.ReactNode;
+  saveButtonProps: SaveButtonProps;
+  showPrevButton: boolean;
+  onCancel: () => void;
+  onNextStep: () => void;
+  onPrevStep: () => void;
+  onSubmit: (e: React.BaseSyntheticEvent) => void;
+}
+
+interface UseExtraSubmitFooterOptions {
+  action: 'create' | 'edit';
+  cancelText: React.ReactNode;
+  defaultSubmitText: React.ReactNode;
+  errorText: React.ReactNode;
+  extraSubmitButton?: RefineFormConfig['extraSubmitButton'];
+  fallbackFooter?: React.ReactNode;
+  isYamlMode: boolean;
+  nextStepText: React.ReactNode;
+  prevStepText: React.ReactNode;
+  saveButtonProps: SaveButtonProps;
+  step: number;
+  stepCount: number;
+  onCancel: () => void;
+  onNextStep: () => void;
+  onPrevStep: () => void;
+  onSubmit: (e: React.BaseSyntheticEvent) => void;
+}
+
+export function useExtraSubmitFooter({
+  action,
+  cancelText,
+  defaultSubmitText,
+  errorText,
+  extraSubmitButton,
+  fallbackFooter,
+  isYamlMode,
+  nextStepText,
+  prevStepText,
+  saveButtonProps,
+  step,
+  stepCount,
+  onCancel,
+  onNextStep,
+  onPrevStep,
+  onSubmit,
+}: UseExtraSubmitFooterOptions) {
+  const shouldShowExtraSubmitButton = useMemo(() => {
+    // 额外提交按钮只在配置的表单模式、操作类型和步骤上出现；最后一步已有默认提交按钮，因此始终隐藏。
+    if (!extraSubmitButton || isYamlMode) {
+      return false;
+    }
+    if (extraSubmitButton.action && extraSubmitButton.action !== action) {
+      return false;
+    }
+    if (extraSubmitButton.step !== step) {
+      return false;
+    }
+
+    return step < stepCount - 1;
+  }, [action, extraSubmitButton, isYamlMode, step, stepCount]);
+
+  return useMemo(() => {
+    if (!shouldShowExtraSubmitButton) {
+      return fallbackFooter;
+    }
+
+    return (
+      <ExtraSubmitFooter
+        cancelText={cancelText}
+        errorText={errorText}
+        extraSubmitText={extraSubmitButton?.text || defaultSubmitText}
+        nextStepText={nextStepText}
+        prevText={prevStepText}
+        saveButtonProps={saveButtonProps}
+        showPrevButton={step > 0}
+        onCancel={onCancel}
+        onNextStep={onNextStep}
+        onPrevStep={onPrevStep}
+        onSubmit={onSubmit}
+      />
+    );
+  }, [
+    cancelText,
+    defaultSubmitText,
+    errorText,
+    extraSubmitButton?.text,
+    fallbackFooter,
+    onCancel,
+    onNextStep,
+    onPrevStep,
+    onSubmit,
+    nextStepText,
+    prevStepText,
+    saveButtonProps,
+    shouldShowExtraSubmitButton,
+    step,
+  ]);
+}
+
+const ExtraSubmitFooter: React.FC<ExtraSubmitFooterProps> = ({
+  cancelText,
+  errorText,
+  extraSubmitText,
+  nextStepText,
+  prevText,
+  saveButtonProps,
+  showPrevButton,
+  onCancel,
+  onNextStep,
+  onPrevStep,
+  onSubmit,
+}) => {
+  const finalSaveButtonProps = omit(saveButtonProps, 'onClick');
+
+  // WizardDialog 没有右侧额外按钮插槽，因此仅在需要快捷提交时复刻默认 footer，并保留原有错误、取消和上一步行为。
+  return (
+    <div className={FooterStyle}>
+      <div className={FooterLeftStyle}>
+        {showPrevButton ? (
+          <Button type="link" onClick={onPrevStep}>
+            <ArrowChevronLeft16BoldBlueIcon className={PrevIconStyle} />
+            {prevText}
+          </Button>
+        ) : null}
+        {errorText ? (
+          <span className={cx(ErrorStyle, Typo.Label.l2_regular)}>
+            <ExclamationErrorCircleFill16RedIcon className={ErrorIconStyle} />
+            {errorText}
+          </span>
+        ) : null}
+      </div>
+      <div className={FooterRightStyle}>
+        <Button type="quiet" size="large" onClick={onCancel}>
+          <span className={Typo.Label.l1_bold_title}>{cancelText}</span>
+        </Button>
+        <Button
+          size="large"
+          type="secondary"
+          onClick={onNextStep}
+        >
+          {nextStepText}
+        </Button>
+        <Button
+          {...finalSaveButtonProps}
+          size="large"
+          type="primary"
+          onClick={onSubmit}
+        >
+          {/* 直接复用 onSubmit，确保快捷提交也走 transformApplyValues、beforeSubmit 和成功关闭逻辑。 */}
+          {extraSubmitText}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/packages/refine/src/components/Form/FormModal.tsx
+++ b/packages/refine/src/components/Form/FormModal.tsx
@@ -16,6 +16,7 @@ import { SmallModalStyle } from 'src/styles/modal';
 import { FormType, FormMode, RefineFormConfig, CommonFormConfig } from 'src/types';
 import { ResourceConfig } from 'src/types';
 import { transformResourceKindInSentence } from 'src/utils/string';
+import { useExtraSubmitFooter } from './ExtraSubmitFooter';
 import FormModeSegmentControl from './FormModeSegmentControl';
 import RefineFormContainer, { RefineFormContainerRef } from './RefineFormContainer';
 import { YamlFormProps } from './YamlForm';
@@ -278,6 +279,28 @@ export function FormModal(props: FormModalProps) {
     },
     [step]
   );
+  const extraSubmitButton =
+    resourceConfig.formConfig?.formType === FormType.FORM
+      ? resourceConfig.formConfig.extraSubmitButton
+      : undefined;
+  const footer = useExtraSubmitFooter({
+    action,
+    cancelText: modalProps?.cancelText || i18n.t('dovetail.cancel'),
+    defaultSubmitText: okText,
+    errorText,
+    extraSubmitButton,
+    fallbackFooter: modalProps?.footer,
+    isYamlMode,
+    nextStepText: modalProps?.nextText || i18n.t('dovetail.next_step'),
+    prevStepText: modalProps?.prevText || i18n.t('dovetail.prev_step'),
+    saveButtonProps,
+    step,
+    stepCount: steps?.length || 0,
+    onCancel: popModal,
+    onNextStep: () => handleStepChange(step + 1),
+    onPrevStep: () => handleStepChange(step - 1),
+    onSubmit: onOk,
+  });
 
   return (
     <WizardDialog
@@ -308,6 +331,7 @@ export function FormModal(props: FormModalProps) {
         children: resourceConfig.formConfig?.saveButtonText,
       }}
       okText={resourceConfig.formConfig?.saveButtonText || okText}
+      footer={footer}
       destroyOnClose
       destroyOtherStep
       {...modalProps}

--- a/packages/refine/src/locales/en-US/dovetail.json
+++ b/packages/refine/src/locales/en-US/dovetail.json
@@ -18,6 +18,8 @@
   "name": "Name",
   "pod": "Pod",
   "cancel": "Cancel",
+  "prev_step": "Previous",
+  "next_step": "Next",
   "delete": "Delete",
   "create": "Create",
   "confirm_delete_text": "Are you sure you want to delete the {{kind}} <0>{{target}}</0>?",

--- a/packages/refine/src/locales/zh-CN/dovetail.json
+++ b/packages/refine/src/locales/zh-CN/dovetail.json
@@ -10,6 +10,8 @@
   "copied": "已复制",
   "already_reset": "已重置",
   "cancel": "取消",
+  "prev_step": "上一步",
+  "next_step": "下一步",
   "delete": "删除",
   "create": "创建",
   "delete_resource": "删除{{resource}}",

--- a/packages/refine/src/types/resource.ts
+++ b/packages/refine/src/types/resource.ts
@@ -48,6 +48,15 @@ export type RefineFormConfig<Model extends ResourceModel = ResourceModel> = {
   steps?: {
     title: string;
   }[]
+  /** 在指定步骤展示额外提交按钮，用于跳过后续可选步骤并复用当前表单提交链路。 */
+  extraSubmitButton?: {
+    /** 按钮生效的表单操作类型；不填则创建和编辑都生效。 */
+    action?: 'create' | 'edit';
+    /** 按钮出现的步骤索引，从 0 开始。 */
+    step: number;
+    /** 按钮文案；不填则使用当前表单默认提交文案。 */
+    text?: string;
+  };
   /**
  * 表单字段配置函数
  * @param props 包含记录和动作类型的配置对象


### PR DESCRIPTION
## 变更说明

- 为 D2 FormModal 增加 extraSubmitButton 配置，支持在指定步骤展示额外提交按钮。
- 额外提交按钮复用原有提交链路，保持 transformApplyValues、beforeSubmit、错误展示和成功关闭行为一致。
- 补充中英文步骤文案和配置字段注释。

<img width="795" height="763" alt="截屏2026-05-13 16 40 17" src="https://github.com/user-attachments/assets/e44f2b21-9b49-4408-9c94-e3b72604b17a" />



## 验证

- 用户已在 SKS UI 中通过本地 file 依赖完成联调验证。
- 已检查 D2 分支 diff，无空白错误。