### PR TITLE
feat: FormModal support for non-K8s resources

### DIFF
--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.4.1",
+  "version": "0.4.2-alpha.2",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/src/components/EditMetadataForm/LabelFormatPopover.tsx
+++ b/packages/refine/src/components/EditMetadataForm/LabelFormatPopover.tsx
@@ -1,66 +1,7 @@
-import { AntdTable, Button, Popover, Typo } from '@cloudtower/eagle';
-import { css } from '@linaria/core';
+import { Typo } from '@cloudtower/eagle';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-
-export const PodLabelFormatRulePopoverStyle = css`
-  .ant-popover-inner {
-    border-radius: 8px;
-  }
-
-  .ant-popover-innerntent {
-    padding: 12px;
-  }
-
-  .ant-popover-content {
-    & > .ant-popover-arrow {
-      display: none;
-    }
-  }
-
-  td.ant-table-cell {
-    vertical-align: middle;
-  }
-
-  .rule-list {
-    list-style: disc;
-    list-style-position: inside;
-  }
-
-  .ant-table {
-    font-size: 12px;
-    line-height: 18px;
-
-    .ant-table-container {
-      border: none !important;
-    }
-
-    .ant-table-thead {
-      font-weight: 700;
-    }
-
-    .ant-table-thead > tr > th {
-      background: $white;
-    }
-
-    thead > tr > th:last-child,
-    tbody > tr > td:last-child {
-      border-right: none !important;
-    }
-
-    tbody > tr:last-child > td {
-      border-bottom: none;
-    }
-
-    .ant-table-cell {
-      padding: 4px 8px !important;
-    }
-
-    li {
-      text-indent: 8px;
-    }
-  }
-`;
+import { FormatRulePopover } from '../KeyValueTableForm/FormatRulePopover';
 
 export const LabelFormatPopover: React.FC<{
   noValueValidation?: boolean;
@@ -111,60 +52,44 @@ export const LabelFormatPopover: React.FC<{
   }
 
   return (
-    <Popover
-      trigger="click"
-      overlayClassName={PodLabelFormatRulePopoverStyle}
-      placement="bottomRight"
-      content={
-        <AntdTable
-          bordered
-          dataSource={data}
-          columns={[
-            {
-              key: 'object',
-              title: t('dovetail.object'),
-              dataIndex: 'object',
-              render: (cell, record, index) => {
-                return {
-                  children: <span className={Typo.Label.l4_bold}>{cell}</span>,
-                  props: {
-                    rowSpan: index === 0 ? 2 : index === 1 ? 0 : 1,
-                  },
-                };
-              },
+    <FormatRulePopover
+      buttonText={t('dovetail.look_format_requirement')}
+      dataSource={data}
+      columns={[
+        {
+          key: 'object',
+          title: t('dovetail.object'),
+          dataIndex: 'object',
+          render: (cell: string, _record: unknown, index: number) => ({
+            children: <span className={Typo.Label.l4_bold}>{cell}</span>,
+            props: {
+              rowSpan: index === 0 ? 2 : index === 1 ? 0 : 1,
             },
-            {
-              key: 'contains',
-              title: t('dovetail.contains'),
-              dataIndex: 'contains',
-            },
-            {
-              key: 'optional',
-              title: t('dovetail.optional'),
-              dataIndex: 'optional',
-            },
-            {
-              key: 'rule',
-              title: t('dovetail.format_requirements'),
-              dataIndex: 'rule',
-              render: (cell: string[]) => {
-                return (
-                  <ul className="rule-list">
-                    {cell.map((rule, index) => (
-                      <li key={index}>{rule}</li>
-                    ))}
-                  </ul>
-                );
-              },
-            },
-          ]}
-          pagination={false}
-        />
-      }
-    >
-      <Button size="small" type="link">
-        {t('dovetail.look_format_requirement')}
-      </Button>
-    </Popover>
+          }),
+        },
+        {
+          key: 'contains',
+          title: t('dovetail.contains'),
+          dataIndex: 'contains',
+        },
+        {
+          key: 'optional',
+          title: t('dovetail.optional'),
+          dataIndex: 'optional',
+        },
+        {
+          key: 'rule',
+          title: t('dovetail.format_requirements'),
+          dataIndex: 'rule',
+          render: (cell: string[]) => (
+            <ul style={{ listStyle: 'disc', listStylePosition: 'inside' }}>
+              {cell.map((rule, i) => (
+                <li key={i} style={{ textIndent: 8 }}>{rule}</li>
+              ))}
+            </ul>
+          ),
+        },
+      ]}
+    />
   );
 };

--- a/packages/refine/src/components/Form/RefineFormContainer.tsx
+++ b/packages/refine/src/components/Form/RefineFormContainer.tsx
@@ -122,6 +122,7 @@ const RefineFormContainer = React.forwardRef<
         isShowLayout: false,
         useFormProps: {
           redirect: false,
+          mutationMeta: formConfig?.refineCoreProps?.mutationMeta,
         },
         rules: fieldsConfig
           ?.filter(
@@ -154,6 +155,7 @@ const RefineFormContainer = React.forwardRef<
     id,
     refineFormResult,
     formConfig?.beforeSubmit,
+    formConfig?.refineCoreProps?.mutationMeta,
     transformApplyValues,
     onSaveButtonPropsChange,
     onSuccess,
@@ -177,10 +179,11 @@ const RefineFormContainer = React.forwardRef<
   );
 
   // 等获取到真实数据后再渲染表单
-  if (
-    action === 'edit' &&
-    !(refineFormResult.formResult.getValues() as Unstructured)?.metadata?.name
-  ) {
+  const currentFormValues = refineFormResult.formResult.getValues();
+  const isReady = formConfig?.isDataReady
+    ? formConfig.isDataReady(currentFormValues as Record<string, unknown>)
+    : !!(currentFormValues as Unstructured)?.metadata?.name;
+  if (action === 'edit' && !isReady) {
     return <Loading />;
   }
 
@@ -190,10 +193,12 @@ const RefineFormContainer = React.forwardRef<
 
   return (
     <>
-      {!formConfig?.isDisabledChangeMode ? (
+      {!formConfig?.isDisabledChangeMode && formConfig?.changeModeAlert !== false ? (
         <Alert
           type="warning"
-          message={i18n.t('dovetail.change_form_mode_alert')}
+          message={
+            formConfig?.changeModeAlert ?? i18n.t('dovetail.change_form_mode_alert')
+          }
           style={{ marginBottom: '16px' }}
         />
       ) : undefined}

--- a/packages/refine/src/components/Form/useRefineForm.ts
+++ b/packages/refine/src/components/Form/useRefineForm.ts
@@ -43,6 +43,12 @@ export const useRefineForm = (props: {
     refineCoreProps: {
       errorNotification: false,
       successNotification: () => {
+        if (formConfig?.successMessage) {
+          const msg = typeof formConfig.successMessage === 'function'
+            ? formConfig.successMessage(id ? 'edit' : 'create')
+            : formConfig.successMessage;
+          return { message: msg, description: 'Success', type: 'success' as const };
+        }
         const formValue = result.getValues() as Unstructured;
 
         return {
@@ -57,7 +63,7 @@ export const useRefineForm = (props: {
             })
             .trim(),
           description: 'Success',
-          type: 'success',
+          type: 'success' as const,
         };
       },
       resource: resourceConfig.name,

--- a/packages/refine/src/components/KeyValueTableForm/FormatRulePopover.tsx
+++ b/packages/refine/src/components/KeyValueTableForm/FormatRulePopover.tsx
@@ -1,0 +1,75 @@
+import { AntdTable, Button, Popover } from '@cloudtower/eagle';
+import { css } from '@linaria/core';
+import React from 'react';
+
+const FormatRulePopoverStyle = css`
+  .ant-popover-inner {
+    border-radius: 8px;
+  }
+
+  .ant-popover-content > .ant-popover-arrow {
+    display: none;
+  }
+
+  .ant-table {
+    font-size: 12px;
+    line-height: 18px;
+
+    .ant-table-container {
+      border: none !important;
+    }
+
+    .ant-table-thead {
+      font-weight: 700;
+    }
+
+    .ant-table-thead > tr > th {
+      background: $white;
+    }
+
+    thead > tr > th:last-child,
+    tbody > tr > td:last-child {
+      border-right: none !important;
+    }
+
+    tbody > tr:last-child > td {
+      border-bottom: none;
+    }
+
+    .ant-table-cell {
+      padding: 4px 8px !important;
+      vertical-align: middle;
+    }
+  }
+`;
+
+export interface FormatRulePopoverProps {
+  buttonText: string;
+  columns: Record<string, unknown>[];
+  dataSource: Record<string, unknown>[];
+}
+
+export const FormatRulePopover: React.FC<FormatRulePopoverProps> = ({
+  buttonText,
+  columns,
+  dataSource,
+}) => (
+  <Popover
+    trigger="click"
+    overlayClassName={FormatRulePopoverStyle}
+    placement="bottomRight"
+    content={
+      <AntdTable
+        bordered
+        dataSource={dataSource}
+        columns={columns}
+        pagination={false}
+        rowKey={(_, index) => String(index)}
+      />
+    }
+  >
+    <Button size="small" type="link">
+      {buttonText}
+    </Button>
+  </Popover>
+);

--- a/packages/refine/src/components/KeyValueTableForm/index.tsx
+++ b/packages/refine/src/components/KeyValueTableForm/index.tsx
@@ -47,6 +47,7 @@ interface KeyValueTableFormProps<T extends KeyValuePair> {
   validateValue?: (value: string) => { isValid: boolean; errorMessage?: string };
   onSubmit?: (value: T[]) => Promise<unknown> | undefined;
   keyTitle?: string;
+  formatPopover?: React.ReactNode;
 }
 
 export type KeyValueTableFormHandle<T extends KeyValuePair = KeyValuePair> = {
@@ -77,6 +78,7 @@ function _KeyValueTableForm<RowType extends KeyValuePair>(
     validateValue,
     onSubmit,
     keyTitle,
+    formatPopover,
   } = props;
   const { t, i18n } = useTranslation();
   const tableFormRef = useRef<TableFormHandle>(null);
@@ -304,10 +306,13 @@ function _KeyValueTableForm<RowType extends KeyValuePair>(
         hideEmptyTable
       />
       {isHideLabelFormatPopover || _value.length === 0 ? null : (
-        <LabelFormatPopover noValueValidation={noValueValidation} />
+        formatPopover ?? <LabelFormatPopover noValueValidation={noValueValidation} />
       )}
     </Space>
   );
 }
 
 export const KeyValueTableForm = React.forwardRef(_KeyValueTableForm);
+
+export { FormatRulePopover } from './FormatRulePopover';
+export type { FormatRulePopoverProps } from './FormatRulePopover';

--- a/packages/refine/src/types/resource.ts
+++ b/packages/refine/src/types/resource.ts
@@ -163,6 +163,21 @@ export type CommonFormConfig<Model extends ResourceModel = ResourceModel> = {
    * 路径映射，用于在表单中映射路径
    */
   pathMap?: { from: string[]; to: string[] }[];
+  /**
+   * 自定义数据就绪检查（编辑模式下判断初始数据是否加载完成）
+   * 默认检查 metadata.name，非标准 K8s 资源可覆盖
+   */
+  isDataReady?: (formValues: Record<string, unknown>) => boolean;
+  /**
+   * 自定义成功 toast 消息
+   */
+  successMessage?: string | ((action: 'create' | 'edit') => string);
+  /**
+   * 自定义切换 YAML 模式时的提示 Alert 内容
+   * 设为 false 可隐藏 Alert，设为 string/ReactNode 可替换默认文案
+   * 默认显示 dovetail.change_form_mode_alert
+   */
+  changeModeAlert?: React.ReactNode | false;
 };
 
 export type ResourceConfig<Model extends ResourceModel = ResourceModel> = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,7 +121,7 @@ importers:
       jest-environment-jsdom: ^30.0.0
       js-yaml: ^4.1.0
       json-schema: ^0.4.0
-      k8s-api-provider: ^0.0.36
+      k8s-api-provider: ^0.0.37
       kubernetes-types: ^1.26.0
       ky: ^0.33.3
       lodash: ^4.17.21
@@ -163,7 +163,7 @@ importers:
       dayjs: 1.11.10
       i18next: 23.6.0
       js-yaml: 4.1.0
-      k8s-api-provider: 0.0.36_@refinedev+core@4.47.2
+      k8s-api-provider: 0.0.37_@refinedev+core@4.47.2
       ky: 0.33.3
       lodash-es: 4.17.22
       mitt: 3.0.1
@@ -9185,8 +9185,8 @@ packages:
       object.values: 1.1.7
     dev: true
 
-  /k8s-api-provider/0.0.36_@refinedev+core@4.47.2:
-    resolution: {integrity: sha512-aJSIP5zTS1TBvcMPNt/mT3ui7wIF2+O7f11Fspb2k3tEtvE8iAa7fXpQtAeKaGlrl3rtXNsmqsOz08H6eWwZrA==}
+  /k8s-api-provider/0.0.37_@refinedev+core@4.47.2:
+    resolution: {integrity: sha512-m5YV1QBMI02/TwsKNIN8pvDSSJS7lhouBTYE+kgDdu3lu+E7qYK2WJMsHTdSzaS04xByZuz5w95bT78OAcFoCQ==}
     peerDependencies:
       '@refinedev/core': ^4.44.4
     dependencies:
@@ -10466,7 +10466,7 @@ packages:
     dev: true
 
   /path-to-regexp/1.8.0:
-    resolution: {integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==, tarball: path-to-regexp/-/path-to-regexp-1.8.0.tgz}
+    resolution: {integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==}
     deprecated: '[WARNING] Use 1.9.0 instead of 1.8.0, reason: https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-9wv6-86v2-598j'
     dependencies:
       isarray: 0.0.1


### PR DESCRIPTION
## Summary

- Add `isDataReady`, `successMessage`, `changeModeAlert` to `CommonFormConfig` for non-K8s resource form scenarios
- Decouple `RefineFormContainer` from K8s assumptions (metadata.name guard, fixed alert, YAML mode mutationMeta)
- Extract reusable `FormatRulePopover` component and add `formatPopover` prop to `KeyValueTableForm`

## Motivation

FormModal's internal logic was tightly coupled to K8s resources (metadata.name loading guard, hardcoded success toast, fixed mode-switch alert). This prevents reuse for editing nested fields within a K8s resource (e.g. KSC's `spec.components.logging`). These changes add optional configuration hooks that keep full backward compatibility while enabling custom form scenarios.

## Changes

### New `CommonFormConfig` fields (all optional, backward compatible)

| Field | Type | Purpose |
|-------|------|---------|
| `isDataReady` | `(formValues) => boolean` | Custom edit-mode data readiness check (default: `metadata.name`) |
| `successMessage` | `string \| ((action) => string)` | Custom success toast message |
| `changeModeAlert` | `ReactNode \| false` | Custom or hidden FORM/YAML switch alert |

### Other improvements

- YAML mode now inherits `mutationMeta` from `formConfig.refineCoreProps` (previously hardcoded to `{ updateType: 'put' }`)
- Extract `FormatRulePopover` from `LabelFormatPopover` for reuse; add `formatPopover` prop to `KeyValueTableForm`

## Test plan

- [ ] Existing K8s resource forms (Deployment, ConfigMap, etc.) behave identically
- [ ] `successMessage` overrides default toast in FORM mode
- [ ] `isDataReady` prevents infinite loading for non-metadata resources
- [ ] `changeModeAlert: false` hides the alert; custom ReactNode replaces it
- [ ] FORM → YAML switch preserves `mutationMeta` configuration
- [ ] `formatPopover` prop on `KeyValueTableForm` renders custom popover