### PR TITLE
fix: preserve 409 retry baseline across form modes

### DIFF
--- a/packages/refine/__tests__/hooks/use409Retry.spec.ts
+++ b/packages/refine/__tests__/hooks/use409Retry.spec.ts
@@ -2,7 +2,11 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { Unstructured } from 'k8s-api-provider';
 import { createElement, ReactNode } from 'react';
 import GlobalStoreContext from '../../src/contexts/global-store';
-import { Retry409MetaOptions, use409Retry } from '../../src/hooks/use409Retry';
+import {
+  Retry409Provider,
+  Retry409MetaOptions,
+  use409Retry,
+} from '../../src/hooks/use409Retry';
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -35,6 +39,24 @@ function createWrapper(restoreItem?: (resource: Unstructured) => Unstructured) {
         } as any,
       },
       children
+    );
+  };
+}
+
+function createSharedRetryWrapper(
+  restoreItem?: (resource: Unstructured) => Unstructured
+) {
+  return function Wrapper({ children }: { children?: ReactNode }) {
+    return createElement(
+      GlobalStoreContext.Provider,
+      {
+        value: {
+          default: {
+            restoreItem,
+          },
+        } as any,
+      },
+      createElement(Retry409Provider, null, children)
     );
   };
 }
@@ -151,5 +173,51 @@ describe('use409Retry', () => {
     );
     expect(getRetryMeta(result.current.mutationMeta).initialResource).toBeUndefined();
     expect(result.current.mutationMeta.updateType).toBe('put');
+  });
+
+  it('shares the captured initial resource across form modes', () => {
+    const restoreItem = jest.fn((resource: Unstructured) => ({
+      ...resource,
+      metadata: {
+        ...resource.metadata,
+        resourceVersion: `raw-${resource.metadata?.resourceVersion}`,
+      },
+    }));
+    const { result } = renderHook(
+      () => ({
+        formModeRetry: use409Retry({
+          action: 'edit',
+          dataProviderName: 'default',
+          id: 'default/test',
+          mutationMeta: {
+            updateType: 'put',
+          },
+        }),
+        yamlModeRetry: use409Retry({
+          action: 'edit',
+          dataProviderName: 'default',
+          id: 'default/test',
+          mutationMeta: {
+            updateType: 'put',
+          },
+        }),
+      }),
+      {
+        wrapper: createSharedRetryWrapper(restoreItem),
+      }
+    );
+
+    act(() => {
+      result.current.formModeRetry.captureInitialResource(makeResource('1'));
+    });
+    act(() => {
+      result.current.yamlModeRetry.captureInitialResource(makeResource('2'));
+    });
+
+    expect(
+      getRetryMeta(result.current.yamlModeRetry.mutationMeta).initialResource?.metadata
+        ?.resourceVersion
+    ).toBe('raw-1');
+    expect(restoreItem).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/src/components/Form/FormModal.tsx
+++ b/packages/refine/src/components/Form/FormModal.tsx
@@ -11,6 +11,7 @@ import { BaseRecord, CreateResponse, UpdateResponse } from '@refinedev/core';
 import { omit } from 'lodash-es';
 import React, { useState, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Retry409Provider } from 'src/hooks/use409Retry';
 import { WarningButtonStyle } from 'src/styles/button';
 import { SmallModalStyle } from 'src/styles/modal';
 import { FormType, FormMode, RefineFormConfig, CommonFormConfig } from 'src/types';
@@ -279,40 +280,42 @@ export function FormModal(props: FormModalProps) {
   );
 
   return (
-    <WizardDialog
-      style={
-        {
-          '--max-modal-width': isYamlForm || !isDisabledChangeMode ? '1024px' : '648px',
-        } as React.CSSProperties
-      }
-      title={
-        <div className={TitleWrapperStyle}>
-          <span>{title}</span>
-          {resourceConfig.formConfig?.formType === FormType.FORM ? (
-            <FormModeSegmentControl
-              formConfig={resourceConfig.formConfig}
-              mode={mode}
-              onChangeMode={onChangeMode}
-            />
-          ) : null}
-        </div>
-      }
-      error={errorText}
-      steps={steps}
-      step={step}
-      onStepChange={handleStepChange}
-      onOk={onOk}
-      okButtonProps={{
-        ...omit(saveButtonProps, 'onClick'),
-        children: resourceConfig.formConfig?.saveButtonText,
-      }}
-      okText={resourceConfig.formConfig?.saveButtonText || okText}
-      destroyOnClose
-      destroyOtherStep
-      {...modalProps}
-    >
-      {desc ? <div className={FormDescStyle}>{desc}</div> : undefined}
-      {formEle}
-    </WizardDialog>
+    <Retry409Provider>
+      <WizardDialog
+        style={
+          {
+            '--max-modal-width': isYamlForm || !isDisabledChangeMode ? '1024px' : '648px',
+          } as React.CSSProperties
+        }
+        title={
+          <div className={TitleWrapperStyle}>
+            <span>{title}</span>
+            {resourceConfig.formConfig?.formType === FormType.FORM ? (
+              <FormModeSegmentControl
+                formConfig={resourceConfig.formConfig}
+                mode={mode}
+                onChangeMode={onChangeMode}
+              />
+            ) : null}
+          </div>
+        }
+        error={errorText}
+        steps={steps}
+        step={step}
+        onStepChange={handleStepChange}
+        onOk={onOk}
+        okButtonProps={{
+          ...omit(saveButtonProps, 'onClick'),
+          children: resourceConfig.formConfig?.saveButtonText,
+        }}
+        okText={resourceConfig.formConfig?.saveButtonText || okText}
+        destroyOnClose
+        destroyOtherStep
+        {...modalProps}
+      >
+        {desc ? <div className={FormDescStyle}>{desc}</div> : undefined}
+        {formEle}
+      </WizardDialog>
+    </Retry409Provider>
   );
 }

--- a/packages/refine/src/hooks/use409Retry.ts
+++ b/packages/refine/src/hooks/use409Retry.ts
@@ -1,6 +1,15 @@
 import { Unstructured } from 'k8s-api-provider';
 import { cloneDeep, omit } from 'lodash-es';
-import { useCallback, useMemo, useRef } from 'react';
+import {
+  createContext,
+  createElement,
+  MutableRefObject,
+  ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { useGlobalStore } from './useGlobalStore';
 
@@ -34,6 +43,42 @@ type Use409RetryResult = {
   mutationMeta: Record<string, unknown>;
 };
 
+type InitialResourceRef = MutableRefObject<Unstructured | undefined>;
+
+type Retry409ProviderProps = {
+  /** 需要共享同一份初始版本的表单内容，例如同一个编辑弹窗内的 FORM 和 YAML 模式。 */
+  children?: ReactNode;
+};
+
+const ResourceVersionConflictRetryContext = createContext<InitialResourceRef | null>(null);
+
+/**
+ * 为同一个编辑弹窗内的多个表单模式共享 409 重试初始版本。
+ *
+ * 背景：FORM 模式保存失败后，如果用户切换到 YAML 模式，YAML 表单会重新挂载。
+ * 如果每个模式都维护自己的初始版本，YAML 可能捕获到已经变化的服务端版本，
+ * 导致 provider 误以为初始版本和服务端版本一致，从而允许覆盖保存。
+ *
+ * 用法：在表单弹窗层包裹一次，内部所有 `use409Retry` 会共用同一个 ref。
+ *
+ * @param props - Provider 属性。
+ * @param props.children - 需要共享初始版本的子节点。
+ * @returns 包裹后的 React 节点。
+ */
+export function Retry409Provider({
+  children,
+}: Retry409ProviderProps) {
+  const initialResourceRef = useRef<Unstructured>();
+
+  return createElement(
+    ResourceVersionConflictRetryContext.Provider,
+    {
+      value: initialResourceRef,
+    },
+    children
+  );
+}
+
 /**
  * 为 D2 编辑表单接入 Kubernetes PUT 409 自动恢复能力。
  *
@@ -61,7 +106,9 @@ export function use409Retry({
 }: Use409RetryOptions): Use409RetryResult {
   const { t } = useTranslation();
   const globalStore = useGlobalStore(dataProviderName);
-  const initialResourceRef = useRef<Unstructured>();
+  const sharedInitialResourceRef = useContext(ResourceVersionConflictRetryContext);
+  const localInitialResourceRef = useRef<Unstructured>();
+  const initialResourceRef = sharedInitialResourceRef || localInitialResourceRef;
   const isEditAction = action === 'edit' || !!id;
 
   const captureInitialResource = useCallback((resource?: Unstructured) => {
@@ -77,7 +124,7 @@ export function use409Retry({
     }
 
     initialResourceRef.current = cloneDeep(rawResource);
-  }, [globalStore, isEditAction]);
+  }, [globalStore, initialResourceRef, isEditAction]);
 
   const retryMutationMeta = useMemo(() => {
     const restMutationMeta = omit(mutationMeta, 'resourceVersionConflictRetry');
@@ -96,7 +143,7 @@ export function use409Retry({
         conflictMessage: t('dovetail.resource_version_conflict'),
       },
     };
-  }, [isEditAction, mutationMeta, t]);
+  }, [initialResourceRef, isEditAction, mutationMeta, t]);
 
   return {
     captureInitialResource,


### PR DESCRIPTION
## 背景

之前的 409 冲突恢复机制中，FORM 和 YAML 模式各自维护一份 `use409Retry` 初始版本。

当 FORM 保存遇到 409，并且 provider 判断服务端 `spec` 已有真实变化后，会正确终止保存并报错。但用户此时切换到 YAML 模式，YAML 表单会重新挂载并重新捕获服务端当前资源作为“初始版本”，导致 provider 后续误判初始版本和服务端版本一致，从而覆盖 `resourceVersion` 并保存成功。

## 方案

- 新增 `Retry409Provider`，在同一个 `FormModal` 内共享 409 重试的初始版本引用。
- `use409Retry` 优先使用 Provider 中的共享 ref，没有 Provider 时保持原来的本地 ref 行为。
- `FormModal` 外层包裹 `Retry409Provider`，保证 FORM/YAML 模式切换不会重新开始捕获初始版本。
- 增加单测覆盖：FORM 模式捕获初始版本后，YAML 模式再次捕获更新版本时不能覆盖初始版本。
- 将 `@dovetail-v2/refine` 版本从 `0.3.34` 升到 `0.3.35`。

## 验证

<img width="729" height="874" alt="截屏2026-05-27 11 48 36" src="https://github.com/user-attachments/assets/5c467a52-a395-4da2-ad13-fb26b0a18d30" />


- `yarn jest __tests__/hooks/use409Retry.spec.ts --runInBand`
- `yarn tsc --noEmit`
- `yarn lint`
