### PR TITLE
fix: keep edit form initial data stable

### DIFF
--- a/packages/refine/src/components/Form/useReactHookForm.tsx
+++ b/packages/refine/src/components/Form/useReactHookForm.tsx
@@ -13,7 +13,7 @@ import {
 import { Unstructured } from 'k8s-api-provider';
 import get from 'lodash/get';
 import has from 'lodash/has';
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import {
   DefaultValues,
   useForm as useHookForm,
@@ -159,6 +159,7 @@ export const useForm = <
   >(useHookFormResult.getValues());
   const [beforeSubmitErrors, setBeforeSubmitErrors] = useState<string[]>([]);
   const [isBeforeSubmitLoading, setIsBeforeSubmitLoading] = useState(false);
+  const hasAppliedInitialDataRef = useRef(false);
 
   const {
     watch,
@@ -233,8 +234,7 @@ export const useForm = <
   }, [captureInitialResource, queryResult?.data?.data]);
 
   useEffect(() => {
-    // if form is modified, don't override its value.
-    if (formState.isDirty) return;
+    if (hasAppliedInitialDataRef.current || formState.isDirty) return;
 
     const data = queryResult?.data?.data;
     if (!data) return;
@@ -263,6 +263,7 @@ export const useForm = <
         });
       }
     });
+    hasAppliedInitialDataRef.current = true;
     setTransformedInitValues(getValues());
   }, [queryResult?.data, setValue, transformInitValues, formState.isDirty, getValues]);
 


### PR DESCRIPTION
## jira ticket

无

## 问题描述

D2 编辑表单打开后，如果底层资源数据因为 socket、store 更新或 query refetch 发生变化，即使用户还没有修改表单，表单展示值也会被新的服务端数据覆盖，造成编辑表单内容在用户眼前跳变。

## 问题定位

useReactHookForm 会在 queryResult.data 变化且表单未 dirty 时重新执行 setValue，关闭 liveMode 只能减少 live 订阅触发，无法阻止其它 refetch 或 cache 更新路径导致的覆盖。

本次改动通过 hasAppliedInitialDataRef 记录初始数据是否已经写入表单，使同一个表单实例只在第一次拿到查询数据时应用初始值，后续数据变化不再覆盖编辑草稿。

## 自测结果



## 建议测试范围

- 打开任意 K8s 资源编辑表单后，不操作表单，模拟资源数据通过 socket/store 更新，确认表单字段不再跳变。
- 修改表单字段后，确认后续资源更新不会覆盖用户输入。
- 保存编辑表单，确认原有提交和 409 resourceVersion 冲突处理逻辑正常。