### PR TITLE
feat: 添加访问地址复制按钮

### DIFF
--- a/packages/refine/src/components/CopyButton/index.tsx
+++ b/packages/refine/src/components/CopyButton/index.tsx
@@ -1,0 +1,50 @@
+import { Icon, Tooltip } from '@cloudtower/eagle';
+import {
+  ClipboardCopy16GradientBlueIcon,
+  ClipboardCopy16GradientGrayIcon,
+} from '@cloudtower/icons-react';
+import { css, cx } from '@linaria/core';
+import copyToClipboard from 'copy-to-clipboard';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const CopyIconStyle = css`
+  cursor: pointer;
+  margin: 1px 0;
+`;
+
+export type CopyButtonProps = {
+  /** 需要复制到剪贴板的内容。 */
+  value: string;
+  className?: string;
+};
+
+export const CopyButton: React.FC<CopyButtonProps> = ({ value, className }) => {
+  const { i18n } = useTranslation();
+  const [tooltip, setTooltip] = useState(i18n.t('dovetail.copy'));
+
+  return (
+    <Tooltip
+      title={tooltip}
+      onVisibleChange={visible => {
+        if (!visible) {
+          setTimeout(() => {
+            setTooltip(i18n.t('dovetail.copy'));
+          }, 80);
+        }
+      }}
+    >
+      <Icon
+        src={ClipboardCopy16GradientGrayIcon}
+        hoverSrc={ClipboardCopy16GradientBlueIcon}
+        className={cx(CopyIconStyle, className)}
+        iconWidth={16}
+        iconHeight={16}
+        onClick={() => {
+          copyToClipboard(value);
+          setTooltip(i18n.t('dovetail.copied'));
+        }}
+      />
+    </Tooltip>
+  );
+};

--- a/packages/refine/src/components/IngressRulesTable/IngressRulesTable.tsx
+++ b/packages/refine/src/components/IngressRulesTable/IngressRulesTable.tsx
@@ -1,7 +1,9 @@
+import { css } from '@linaria/core';
 import { useList } from '@refinedev/core';
 import { Service } from 'kubernetes-types/core/v1';
 import React, { useMemo, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
+import { CopyButton } from 'src/components/CopyButton';
 import ErrorContent, { ErrorContentType } from 'src/components/ErrorContent';
 import BaseTable from 'src/components/InternalBaseTable';
 import { LinkFallback } from 'src/components/LinkFallback';
@@ -18,6 +20,34 @@ import { ResourceLink } from '../ResourceLink';
 type Props = {
   ingress: IngressModel;
 };
+
+const PathCellStyle = css`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+`;
+
+const PathTextStyle = css`
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  & > * {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`;
+
+const PathCopyStyle = css`
+  flex: 0 0 16px;
+  margin-left: auto;
+`;
 
 export const IngressRulesTable: React.FC<Props> = ({ ingress }) => {
   const { t } = useTranslation();
@@ -56,7 +86,18 @@ export const IngressRulesTable: React.FC<Props> = ({ ingress }) => {
       width: 478,
       sortable: true,
       render(value: string) {
-        return <LinkFallback fullPath={value} />;
+        if (!value) {
+          return <ValueDisplay value="" />;
+        }
+
+        return (
+          <div className={PathCellStyle}>
+            <span className={PathTextStyle}>
+              <LinkFallback fullPath={value} />
+            </span>
+            <CopyButton value={value} className={PathCopyStyle} />
+          </div>
+        );
       },
     },
     {

--- a/packages/refine/src/components/ServiceComponents/index.tsx
+++ b/packages/refine/src/components/ServiceComponents/index.tsx
@@ -1,7 +1,8 @@
-import { Tooltip, Typo, Link } from '@cloudtower/eagle';
+import { Link, Tooltip, Typo } from '@cloudtower/eagle';
 import { css, cx } from '@linaria/core';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { CopyButton } from 'src/components/CopyButton';
 import ValueDisplay from 'src/components/ValueDisplay';
 import { ServiceModel, ServiceTypeEnum } from '../../models';
 
@@ -50,14 +51,77 @@ const DashedUnderlineSpanStyle = css`
   line-height: 18px;
   border-bottom: 1px dashed rgba(107, 128, 167, 0.6);
 `;
+const AccessAddressStyle = css`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  vertical-align: top;
+`;
+type ServiceAccessAddressProps = {
+  /** 访问地址展示内容。 */
+  children: React.ReactNode;
+  /** 点击复制按钮时写入剪贴板的访问地址。 */
+  copyValue: string;
+};
 
+const ServiceAccessAddress: React.FC<ServiceAccessAddressProps> = ({
+  children,
+  copyValue,
+}) => {
+  return (
+    <span className={AccessAddressStyle}>
+      {children}
+      <CopyButton value={copyValue} />
+    </span>
+  );
+};
+
+/**
+ * 渲染 Service 详情页中带复制按钮的外部访问地址列表。
+ *
+ * @param items 每个可访问地址对应的 React 节点。
+ * @param separator 地址之间的分隔符。
+ */
+function renderAccessItems(items: React.ReactNode[], separator: React.ReactNode) {
+  if (!items.length) {
+    return undefined;
+  }
+
+  const result: React.ReactNode[] = [];
+
+  for (let i = 0; i < items.length; i++) {
+    result.push(<React.Fragment key={`item-${i}`}>{items[i]}</React.Fragment>);
+    if (i < items.length - 1) {
+      result.push(<React.Fragment key={`separator-${i}`}>{separator}</React.Fragment>);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * 渲染 Service 集群外访问方式，详情页可通过 showCopyButton 为每个地址添加复制按钮。
+ *
+ * @param service 当前 Service 资源模型。
+ * @param breakLine 是否按换行展示多个访问地址。
+ * @param clusterVip NodePort 类型拼接访问地址时使用的集群 VIP。
+ * @param showDashedUnderline 是否展示协议提示的虚线下划线。
+ * @param showCopyButton 是否在每个访问地址后展示复制按钮。
+ */
 export const ServiceOutClusterAccessComponent: React.FC<
   Props & {
     breakLine?: boolean;
     clusterVip: string;
     showDashedUnderline?: boolean;
+    showCopyButton?: boolean;
   }
-> = ({ service, breakLine = true, clusterVip, showDashedUnderline = true }) => {
+> = ({
+  service,
+  breakLine = true,
+  clusterVip,
+  showDashedUnderline = true,
+  showCopyButton = false,
+}) => {
   const { i18n } = useTranslation();
   const spec = service._rawYaml.spec;
   const status = service._rawYaml.status;
@@ -67,34 +131,40 @@ export const ServiceOutClusterAccessComponent: React.FC<
     case ServiceTypeEnum.NodePort:
       if (!breakLine) {
         content = spec.ports
-          ?.filter(v => !!v)
-          .map(p => [
-            <Link
-              key={p.name}
-              href={`http://${clusterVip}:${p.nodePort}`}
-              target="_blank"
-              className={cx(ShowLinkStyle, Typo.Label.l4_regular_title)}
-            >
-              <Tooltip title={i18n.t('dovetail.default_http_protocol_tooltip')}>
-                <span
-                  className={DashedUnderlineSpanStyle}
-                  style={showDashedUnderline ? undefined : { borderBottom: 'none' }}
-                >{`${clusterVip}:${p.nodePort}`}</span>
-              </Tooltip>
-            </Link>,
-          ]);
+          ?.filter(v => !!v && v.nodePort)
+          .map(p => {
+            const address = `${clusterVip}:${p.nodePort}`;
+            const link = (
+              <Link
+                key={p.name || p.nodePort}
+                href={`http://${address}`}
+                target="_blank"
+                className={cx(ShowLinkStyle, Typo.Label.l4_regular_title)}
+              >
+                <Tooltip title={i18n.t('dovetail.default_http_protocol_tooltip')}>
+                  <span
+                    className={DashedUnderlineSpanStyle}
+                    style={showDashedUnderline ? undefined : { borderBottom: 'none' }}
+                  >
+                    {address}
+                  </span>
+                </Tooltip>
+              </Link>
+            );
+
+            if (!showCopyButton) {
+              return link;
+            }
+
+            return (
+              <ServiceAccessAddress key={p.name || p.nodePort} copyValue={address}>
+                {link}
+              </ServiceAccessAddress>
+            );
+          });
 
         if (content && content instanceof Array) {
-          const result = [];
-
-          for (let i = 0; i < content.length; i++) {
-            result.push(content[i]);
-            if (i < content.length - 1) {
-              result.push(', ');
-            }
-          }
-
-          content = result;
+          content = renderAccessItems(content, ', ');
         }
         break;
       }
@@ -118,6 +188,18 @@ export const ServiceOutClusterAccessComponent: React.FC<
         ));
       return <ul>{content}</ul>;
     case ServiceTypeEnum.ExternalName:
+      if (showCopyButton) {
+        content = renderAccessItems(
+          spec.externalIPs?.map(ip => (
+            <ServiceAccessAddress key={ip} copyValue={ip}>
+              {ip}
+            </ServiceAccessAddress>
+          )) || [],
+          breakLine ? '\n' : ', '
+        );
+        break;
+      }
+
       content = (
         <ValueDisplay
           useOverflow={false}
@@ -126,6 +208,21 @@ export const ServiceOutClusterAccessComponent: React.FC<
       );
       break;
     case ServiceTypeEnum.LoadBalancer:
+      if (showCopyButton) {
+        content = renderAccessItems(
+          status.loadBalancer?.ingress
+            ?.map(({ ip }) => ip)
+            .filter((ip): ip is string => !!ip)
+            .map(ip => (
+              <ServiceAccessAddress key={ip} copyValue={ip}>
+                {ip}
+              </ServiceAccessAddress>
+            )) || [],
+          breakLine ? '\n' : ', '
+        );
+        break;
+      }
+
       content = (
         <ValueDisplay
           useOverflow={false}

--- a/packages/refine/src/components/ShowContent/fields.tsx
+++ b/packages/refine/src/components/ShowContent/fields.tsx
@@ -433,6 +433,7 @@ export const ServiceOutClusterAccessField = <Model extends ServiceModel>(
         breakLine={false}
         clusterVip={clusterVip}
         showDashedUnderline={false}
+        showCopyButton
       />
     );
   },

--- a/packages/refine/src/components/index.ts
+++ b/packages/refine/src/components/index.ts
@@ -3,6 +3,7 @@ export * from './FormWidgets';
 export * from './PageShow';
 export * from './Time';
 export * from './ConditionsTable';
+export * from './CopyButton';
 export * from './FormLayout';
 export * from './FormErrorAlert';
 export * from './PodContainersTable';
@@ -60,4 +61,3 @@ export * from './EditMetadataForm';
 export * from './LabelsAndAnnotationsShow';
 export * from './FormErrorAlert';
 export * from './EditField';
-

--- a/packages/refine/src/pages/ingresses/index.tsx
+++ b/packages/refine/src/pages/ingresses/index.tsx
@@ -1,5 +1,5 @@
 import { i18n } from 'i18next';
-import { Column, BasicGroup } from 'src/components';
+import { Column, BasicGroup, IngressRulesTab } from 'src/components';
 import K8sDropdown from '../../components/Dropdowns/K8sDropdown';
 import { INGRESS_INIT_VALUE } from '../../constants/k8s';
 import {
@@ -31,6 +31,7 @@ export const IngressConfig = (i18n: i18n): ResourceConfig<IngressModel> => ({
         key: 'detail',
         groups: [BasicGroup(i18n)],
       },
+      IngressRulesTab({ i18n }),
     ],
   }),
   initValue: INGRESS_INIT_VALUE,


### PR DESCRIPTION
## 摘要
- Service 详情页的集群外访问方式中，为每个可访问地址添加复制按钮
- Ingress 详情页展示规则 tab，并在规则列表的路径列添加复制按钮
- Ingress 路径列中文字和按钮分离展示，长路径文字省略，复制按钮固定在右侧
- 抽取公共 CopyButton 组件，Service 和 Ingress 复用同一套复制交互
- 通过 showCopyButton 控制 Service 复制按钮展示，保持 Service 列表页展示不变

## 提交拆分
- feat: add service access copy action：抽取 CopyButton，并为 Service 详情页集群外访问地址添加复制按钮
- feat: add ingress rule path copy action：展示 Ingress 规则 tab，并为规则表路径列添加复制按钮

## 验证
<img width="1065" height="476" alt="截屏2026-06-02 11 30 48" src="https://github.com/user-attachments/assets/5c68639e-5712-4c6d-b868-d95566c1e2f5" />
<img width="1115" height="297" alt="截屏2026-06-01 15 49 40" src="https://github.com/user-attachments/assets/11558dbc-25a0-40a6-8727-7ee2d27a1759" />
<img width="1054" height="304" alt="截屏2026-06-01 15 49 29" src="https://github.com/user-attachments/assets/7e9360cb-75ca-4c1a-850a-5623cb3fffad" />
<img width="957" height="306" alt="截屏2026-06-01 15 49 21" src="https://github.com/user-attachments/assets/9b0ddea6-0e62-4b69-a9e9-48d0506180f0" />

