### PR TITLE
YAML 编辑使用 ImmersiveDialog 的全内容布局

### DIFF
--- a/packages/refine/src/components/Form/RawYamlFormModal.tsx
+++ b/packages/refine/src/components/Form/RawYamlFormModal.tsx
@@ -120,6 +120,7 @@ export function RawYamlFormModal(props: RawYamlFormModalProps) {
       }}
       okText={resourceConfig.formConfig?.saveButtonText || okText}
       destroyOnClose
+      isContentFull
     >
       {desc ? <div className={FormDescStyle}>{desc}</div> : undefined}
       {formEle}

--- a/packages/refine/src/hooks/useOpenForm.tsx
+++ b/packages/refine/src/hooks/useOpenForm.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 import { RawYamlFormModal } from 'src/components/Form/RawYamlFormModal';
 import ConfigsContext from 'src/contexts/configs';
 import { useEdit } from 'src/hooks/useEdit';
-import { FormContainerType } from 'src/types';
+import { FormContainerType, FormType } from 'src/types';
 import { ResourceConfig } from 'src/types';
 import { FormModal } from '../components';
 
@@ -55,7 +55,12 @@ export function useOpenForm() {
       if (formType === undefined || formType === FormContainerType.MODAL) {
         pushModal({
           component: () => {
-            if (options?.useYamlEditor) {
+            // YAML-only 资源没有结构化表单，默认编辑入口也应复用专门的 YAML 全屏弹窗。
+            const isYamlOnlyForm =
+              resourceConfig.formConfig?.formType !== FormType.FORM &&
+              !resourceConfig.formConfig?.CustomFormModal;
+
+            if (options?.useYamlEditor || isYamlOnlyForm) {
               return (
                 <RawYamlFormModal
                   id={options?.id}


### PR DESCRIPTION
## 概要
- YAML-only 资源的默认编辑入口统一走 RawYamlFormModal
- 原始 YAML 编辑使用 ImmersiveDialog 的全内容布局
- FORM 资源的普通编辑表单，以及表单内切换到 YAML 的行为保持不变

![Uploading 截屏2026-06-01 17.07.49.png…]()
