### PR TITLE
fix: usePathMap accumulation, YamlEditor setValue and FormModal callback stability

### DIFF
--- a/packages/refine/src/components/Form/FormModal.tsx
+++ b/packages/refine/src/components/Form/FormModal.tsx
@@ -285,6 +285,14 @@ export function FormModal(props: FormModalProps) {
     resourceConfig.formConfig?.formType === FormType.FORM
       ? resourceConfig.formConfig.extraSubmitButton
       : undefined;
+  const onNextStep = useCallback(
+    () => handleStepChange(step + 1),
+    [handleStepChange, step]
+  );
+  const onPrevStep = useCallback(
+    () => handleStepChange(step - 1),
+    [handleStepChange, step]
+  );
   const footer = useExtraSubmitFooter({
     action,
     cancelText: modalProps?.cancelText || i18n.t('dovetail.cancel'),
@@ -299,8 +307,8 @@ export function FormModal(props: FormModalProps) {
     step,
     stepCount: steps?.length || 0,
     onCancel: popModal,
-    onNextStep: () => handleStepChange(step + 1),
-    onPrevStep: () => handleStepChange(step - 1),
+    onNextStep,
+    onPrevStep,
     onSubmit: onOk,
   });
 

--- a/packages/refine/src/hooks/usePathMap.ts
+++ b/packages/refine/src/hooks/usePathMap.ts
@@ -46,15 +46,16 @@ function usePathMap(options: UsePathMapOptions): {
       // Apply each path mapping
       for (const { from, to } of pathMap || []) {
         // Copy value from source path to target path
-        result = immutableSet(initValues, to, get(initValues, from));
+        result = immutableSet(result, to, get(result, from));
 
         // Clean up the source path after copying
         const fromPath = [...from];
         const lastKey = fromPath.pop();
         if (lastKey) {
-          const obj = get(result, fromPath);
-          if (obj && typeof obj === 'object') {
-            delete (obj as Record<string, unknown>)[lastKey];
+          const parent = get(result, fromPath);
+          if (parent && typeof parent === 'object') {
+            const { [lastKey]: _, ...rest } = parent as Record<string, unknown>;
+            result = immutableSet(result, fromPath, rest);
           }
         }
       }
@@ -76,15 +77,16 @@ function usePathMap(options: UsePathMapOptions): {
       // Apply each path mapping in reverse
       for (const { from, to } of pathMap || []) {
         // Copy value from target path back to source path
-        result = immutableSet(values, from, get(result, to));
+        result = immutableSet(result, from, get(result, to));
 
         // Clean up the target path after copying back
         const toPath = [...to];
         const lastKey = toPath.pop();
         if (lastKey) {
-          const obj = get(result, toPath);
-          if (obj && typeof obj === 'object') {
-            delete (obj as Record<string, unknown>)[lastKey];
+          const parent = get(result, toPath);
+          if (parent && typeof parent === 'object') {
+            const { [lastKey]: _, ...rest } = parent as Record<string, unknown>;
+            result = immutableSet(result, toPath, rest);
           }
         }
       }


### PR DESCRIPTION
## 说明（Bug 修复）
- **usePathMap 多路径映射累积错误**：修正每次迭代都从原始输入 `immutableSet` 导致只有最后一条 path 生效；循环内 `delete` 变异改为不可变 spread
- **FormModal 回调引用不稳定**：`onNextStep`/`onPrevStep` 用 `useCallback` 包装，避免 `useMemo` 缓存失效

## 依赖
基于 #343（prettier 格式化基线）。在 #343 合入 `0.4.x-dev` 前，本 PR 的 diff 会包含 98 个文件的格式化改动；#343 合入后即恢复清爽。

## 来源
从 #339 拆分（原 PR 过大，按 reviewer 要求拆分）。

## 验证
- ✅ ESLint 通过（0 error）
- ✅ 单元测试 25/25 通过
