### PR TITLE
refactor: deduplicate model methods and enhance ComponentContext

### DIFF
--- a/packages/refine/src/contexts/component.ts
+++ b/packages/refine/src/contexts/component.ts
@@ -1,10 +1,26 @@
-import { createContext } from 'react';
+import React, { createContext } from 'react';
 import Table from 'src/components/InternalBaseTable';
 import { Tabs } from 'src/components/Tabs';
 
-const ComponentContext = createContext<{
+export interface ComponentContextValue {
   Table?: typeof Table;
   Tabs?: typeof Tabs;
-}>({});
+}
+
+/**
+ * 允许消费者替换框架内部使用的 Table 和 Tabs 组件。
+ * 通过 ComponentContextProvider 注入自定义实现。
+ */
+const ComponentContext = createContext<ComponentContextValue>({});
+
+export function ComponentContextProvider({
+  value,
+  children,
+}: {
+  value: ComponentContextValue;
+  children: React.ReactNode;
+}) {
+  return React.createElement(ComponentContext.Provider, { value }, children);
+}
 
 export default ComponentContext;

--- a/packages/refine/src/contexts/index.ts
+++ b/packages/refine/src/contexts/index.ts
@@ -1,3 +1,4 @@
 export { default as ComponentContext } from './component';
+export { ComponentContextProvider, type ComponentContextValue } from './component';
 export { default as GlobalStoreContext } from './global-store';
 export { default as ConfigsContext } from './configs';

--- a/packages/refine/src/models/daemonset-model.ts
+++ b/packages/refine/src/models/daemonset-model.ts
@@ -1,7 +1,6 @@
 import { GlobalStore, Unstructured } from 'k8s-api-provider';
 import { DaemonSet } from 'kubernetes-types/apps/v1';
 import { ResourceState } from '../constants';
-import { ControllerRevisionModel } from './controller-revison-model';
 import { WorkloadModel } from './workload-model';
 
 type RequiredDaemonSet = Required<DaemonSet> & Unstructured;
@@ -15,25 +14,6 @@ export class DaemonSetModel extends WorkloadModel {
     _globalStore: GlobalStore
   ) {
     super(_rawYaml, _globalStore);
-  }
-
-  getControllerRevisions(controllerVisions: ControllerRevisionModel[]) {
-    return controllerVisions.filter(
-      controllerRevision =>
-        controllerRevision.metadata?.ownerReferences?.some(
-          ownerReference =>
-            ownerReference.kind === 'DaemonSet' &&
-            ownerReference.uid === this.metadata.uid
-        )
-    );
-  }
-
-  getRevision(controllerVisions: ControllerRevisionModel[]) {
-    const myControllerVisions = this.getControllerRevisions(controllerVisions);
-
-    return myControllerVisions.reduce((result, controllerRevision) => {
-      return Math.max(result, Number(controllerRevision.revision || 0));
-    }, 0);
   }
 
   get stateDisplay() {

--- a/packages/refine/src/models/job-model.ts
+++ b/packages/refine/src/models/job-model.ts
@@ -1,11 +1,7 @@
 import { GlobalStore, Unstructured } from 'k8s-api-provider';
 import { Job } from 'kubernetes-types/batch/v1';
-import { PodList } from 'kubernetes-types/core/v1';
-import { sumBy } from 'lodash';
 import { ResourceState } from '../constants';
-import { matchSelector } from '../utils/match-selector';
 import { getSecondsDiff } from '../utils/time';
-import { PodModel } from './pod-model';
 import { WorkloadBaseModel } from './workload-base-model';
 
 type RequiredJob = Required<Job> & Unstructured;
@@ -27,15 +23,10 @@ export class JobModel extends WorkloadBaseModel {
   }
 
   private async getRestarts() {
-    const pods = (await this._globalStore.get('pods', {
-      resourceBasePath: '/api/v1',
-      kind: 'Pod',
-    })) as PodList;
-    const myPods = pods.items.filter(p =>
-      matchSelector(p as PodModel, this.spec?.selector, this.metadata.namespace)
+    this.restarts = await this.fetchRestarts(
+      this.spec?.selector,
+      this.metadata.namespace
     );
-    const result = sumBy(myPods, 'restarts');
-    this.restarts = result;
   }
 
   get duration() {

--- a/packages/refine/src/models/statefulset-model.ts
+++ b/packages/refine/src/models/statefulset-model.ts
@@ -1,7 +1,6 @@
 import { GlobalStore, Unstructured } from 'k8s-api-provider';
 import { StatefulSet } from 'kubernetes-types/apps/v1';
 import { ResourceState } from '../constants';
-import { ControllerRevisionModel } from './controller-revison-model';
 import { WorkloadModel } from './workload-model';
 
 type RequiredStatefulSet = Required<StatefulSet> & Unstructured;
@@ -15,25 +14,6 @@ export class StatefulSetModel extends WorkloadModel {
     _globalStore: GlobalStore
   ) {
     super(_rawYaml, _globalStore);
-  }
-
-  getControllerRevisions(controllerVisions: ControllerRevisionModel[]) {
-    return controllerVisions.filter(
-      controllerRevision =>
-        controllerRevision.metadata?.ownerReferences?.some(
-          ownerReference =>
-            ownerReference.kind === 'StatefulSet' &&
-            ownerReference.uid === this.metadata.uid
-        )
-    );
-  }
-
-  getRevision(controllerVisions: ControllerRevisionModel[]) {
-    const myControllerVisions = this.getControllerRevisions(controllerVisions);
-
-    return myControllerVisions.reduce((result, controllerRevision) => {
-      return Math.max(result, Number(controllerRevision.revision || 0));
-    }, 0);
   }
 
   get stateDisplay() {

--- a/packages/refine/src/models/workload-base-model.ts
+++ b/packages/refine/src/models/workload-base-model.ts
@@ -1,8 +1,11 @@
 import { GlobalStore, Unstructured } from 'k8s-api-provider';
 import type { DaemonSet, Deployment, StatefulSet } from 'kubernetes-types/apps/v1';
 import type { CronJob, Job } from 'kubernetes-types/batch/v1';
-import { Pod, Node } from 'kubernetes-types/core/v1';
+import { Pod, PodList, Node } from 'kubernetes-types/core/v1';
+import { sumBy } from 'lodash';
+import { matchSelector } from '../utils/match-selector';
 import { shortenedImage } from '../utils/string';
+import { PodModel } from './pod-model';
 import { ResourceModel } from './resource-model';
 
 type WorkloadBaseTypes = Required<
@@ -29,5 +32,19 @@ export class WorkloadBaseModel extends ResourceModel<WorkloadBaseTypes> {
         : [];
 
     return containers?.map(container => shortenedImage(container.image || '')) || [];
+  }
+
+  protected async fetchRestarts(
+    selector: Record<string, string> | { matchLabels?: Record<string, string> } | undefined,
+    namespace?: string
+  ): Promise<number> {
+    const pods = (await this._globalStore.get('pods', {
+      resourceBasePath: '/api/v1',
+      kind: 'Pod',
+    })) as PodList;
+    const myPods = pods.items.filter(p =>
+      matchSelector(p as PodModel, selector, namespace)
+    );
+    return sumBy(myPods, 'restarts');
   }
 }

--- a/packages/refine/src/models/workload-model.ts
+++ b/packages/refine/src/models/workload-model.ts
@@ -1,11 +1,10 @@
 import { GlobalStore, Unstructured } from 'k8s-api-provider';
 import type { DaemonSet, Deployment, StatefulSet } from 'kubernetes-types/apps/v1';
-import { PodList } from 'kubernetes-types/core/v1';
-import { cloneDeep, get, set, sumBy } from 'lodash';
+import { cloneDeep, get, set } from 'lodash';
 import { REDEPLOY_TIMESTAMP_KEY } from '../constants';
 import { matchSelector } from '../utils/match-selector';
+import { ControllerRevisionModel } from './controller-revison-model';
 import { IngressModel } from './ingress-model';
-import { PodModel } from './pod-model';
 import { ServiceModel } from './service-model';
 import { WorkloadBaseModel } from './workload-base-model';
 
@@ -32,15 +31,10 @@ export class WorkloadModel extends WorkloadBaseModel {
   }
 
   private async getRestarts() {
-    const pods = (await this._globalStore.get('pods', {
-      resourceBasePath: '/api/v1',
-      kind: 'Pod',
-    })) as PodList;
-    const myPods = pods.items.filter(p =>
-      matchSelector(p as PodModel, this.spec?.selector, this.metadata.namespace)
+    this.restarts = await this.fetchRestarts(
+      this.spec?.selector,
+      this.metadata.namespace
     );
-    const result = sumBy(myPods, 'restarts');
-    this.restarts = result;
   }
 
   private async getServices() {
@@ -100,5 +94,21 @@ export class WorkloadModel extends WorkloadBaseModel {
       set(newOne, 'spec.replicas', value);
     }
     return newOne as WorkloadTypes;
+  }
+
+  getControllerRevisions(controllerRevisions: ControllerRevisionModel[]) {
+    return controllerRevisions.filter(cr =>
+      cr.metadata?.ownerReferences?.some(
+        ref => ref.kind === this.kind && ref.uid === this.metadata.uid
+      )
+    );
+  }
+
+  getRevision(controllerRevisions: ControllerRevisionModel[]) {
+    const myRevisions = this.getControllerRevisions(controllerRevisions);
+    return myRevisions.reduce(
+      (result, cr) => Math.max(result, Number(cr.revision || 0)),
+      0
+    );
   }
 }


### PR DESCRIPTION
## 说明（重构）
- 将 `fetchRestarts()` 提取到 `WorkloadBaseModel` 基类
- `getControllerRevisions()`/`getRevision()` 上移到 `WorkloadModel`，用 `this.kind` 多态过滤替代硬编码 kind
- 删除 `DaemonSetModel`/`StatefulSetModel` 中的重复方法
- 新增 `ComponentContextProvider` 与 `ComponentContextValue` 类型并从 contexts barrel 导出
- 清理 `workload-model` 中重构后变为未使用的 `PodModel` import

## 依赖
基于 #343（prettier 格式化基线）。在 #343 合入 `0.4.x-dev` 前，本 PR 的 diff 会包含 98 个文件的格式化改动；#343 合入后即恢复清爽。

## 来源
从 #339 拆分（原 PR 过大，按 reviewer 要求拆分）。

## 验证
- ✅ ESLint 通过（0 error）
- ✅ 单元测试 25/25 通过
