### PR TITLE
fix: 修复 Service 列表 NodePort 复制按钮展示

### DIFF
--- a/packages/refine/src/components/IngressRulesComponent/PathWithCopy.tsx
+++ b/packages/refine/src/components/IngressRulesComponent/PathWithCopy.tsx
@@ -1,0 +1,45 @@
+import { css } from '@linaria/core';
+import React from 'react';
+import { CopyButton } from 'src/components/CopyButton';
+
+type Props = {
+  value: string;
+  children: React.ReactNode;
+};
+
+const PathCellStyle = css`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+`;
+
+const PathTextStyle = css`
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  & > * {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`;
+
+const PathCopyStyle = css`
+  flex: 0 0 16px;
+  margin-left: auto;
+`;
+
+export const PathWithCopy: React.FC<Props> = ({ value, children }) => {
+  return (
+    <div className={PathCellStyle}>
+      <span className={PathTextStyle}>{children}</span>
+      <CopyButton value={value} className={PathCopyStyle} />
+    </div>
+  );
+};

--- a/packages/refine/src/components/IngressRulesTable/IngressRulesTable.tsx
+++ b/packages/refine/src/components/IngressRulesTable/IngressRulesTable.tsx
@@ -1,9 +1,7 @@
-import { css } from '@linaria/core';
 import { useList } from '@refinedev/core';
 import { Service } from 'kubernetes-types/core/v1';
 import React, { useMemo, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { CopyButton } from 'src/components/CopyButton';
 import { ErrorContent, ErrorContentType } from 'src/components/ErrorContent';
 import BaseTable from 'src/components/InternalBaseTable';
 import { LinkFallback } from 'src/components/LinkFallback';
@@ -15,39 +13,12 @@ import { RuleItem } from 'src/models/ingress-model';
 import { IngressModel } from '../../models';
 import { WithId } from '../../types';
 import { addId } from '../../utils/addId';
+import { PathWithCopy } from '../IngressRulesComponent/PathWithCopy';
 import { ResourceLink } from '../ResourceLink';
 
 type Props = {
   ingress: IngressModel;
 };
-
-const PathCellStyle = css`
-  display: flex;
-  align-items: center;
-  width: 100%;
-  min-width: 0;
-`;
-
-const PathTextStyle = css`
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-
-  & > * {
-    display: block;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-`;
-
-const PathCopyStyle = css`
-  flex: 0 0 16px;
-  margin-left: auto;
-`;
 
 export const IngressRulesTable: React.FC<Props> = ({ ingress }) => {
   const { t } = useTranslation();
@@ -91,12 +62,9 @@ export const IngressRulesTable: React.FC<Props> = ({ ingress }) => {
         }
 
         return (
-          <div className={PathCellStyle}>
-            <span className={PathTextStyle}>
-              <LinkFallback fullPath={value} />
-            </span>
-            <CopyButton value={value} className={PathCopyStyle} />
-          </div>
+          <PathWithCopy value={value}>
+            <LinkFallback fullPath={value} />
+          </PathWithCopy>
         );
       },
     },

--- a/packages/refine/src/components/ServiceComponents/index.tsx
+++ b/packages/refine/src/components/ServiceComponents/index.tsx
@@ -57,6 +57,20 @@ const AccessAddressStyle = css`
   gap: 4px;
   vertical-align: top;
 `;
+const BreakLineListStyle = css`
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+
+  li + li {
+    margin-top: 4px;
+  }
+`;
+const BreakLineItemStyle = css`
+  display: flex;
+  align-items: center;
+  min-width: 0;
+`;
 type ServiceAccessAddressProps = {
   /** 访问地址展示内容。 */
   children: React.ReactNode;
@@ -129,66 +143,62 @@ export const ServiceOutClusterAccessComponent: React.FC<
 
   switch (spec.type) {
     case ServiceTypeEnum.NodePort:
+      content = spec.ports
+        ?.filter(v => !!v && v.nodePort)
+        .map(p => {
+          const address = `${clusterVip}:${p.nodePort}`;
+          const link = (
+            <Link
+              key={p.name || p.nodePort}
+              href={`http://${address}`}
+              target="_blank"
+              className={
+                breakLine
+                  ? cx(Typo.Label.l4_regular_title, BreakLineStyle, LinkStyle)
+                  : cx(ShowLinkStyle, Typo.Label.l4_regular_title)
+              }
+            >
+              <Tooltip title={i18n.t('dovetail.default_http_protocol_tooltip')}>
+                <span
+                  className={DashedUnderlineSpanStyle}
+                  style={showDashedUnderline ? undefined : { borderBottom: 'none' }}
+                >
+                  {address}
+                </span>
+              </Tooltip>
+            </Link>
+          );
+
+          if (!showCopyButton) {
+            return link;
+          }
+
+          return (
+            <ServiceAccessAddress key={p.name || p.nodePort} copyValue={address}>
+              {link}
+            </ServiceAccessAddress>
+          );
+        });
+
       if (!breakLine) {
-        content = spec.ports
-          ?.filter(v => !!v && v.nodePort)
-          .map(p => {
-            const address = `${clusterVip}:${p.nodePort}`;
-            const link = (
-              <Link
-                key={p.name || p.nodePort}
-                href={`http://${address}`}
-                target="_blank"
-                className={cx(ShowLinkStyle, Typo.Label.l4_regular_title)}
-              >
-                <Tooltip title={i18n.t('dovetail.default_http_protocol_tooltip')}>
-                  <span
-                    className={DashedUnderlineSpanStyle}
-                    style={showDashedUnderline ? undefined : { borderBottom: 'none' }}
-                  >
-                    {address}
-                  </span>
-                </Tooltip>
-              </Link>
-            );
-
-            if (!showCopyButton) {
-              return link;
-            }
-
-            return (
-              <ServiceAccessAddress key={p.name || p.nodePort} copyValue={address}>
-                {link}
-              </ServiceAccessAddress>
-            );
-          });
-
         if (content && content instanceof Array) {
           content = renderAccessItems(content, ', ');
         }
         break;
       }
 
-      content = spec.ports
-        ?.filter(v => !!v)
-        .map(p => (
-          <Link
-            key={p.nodePort}
-            href={`http://${clusterVip}:${p.nodePort}`}
-            target="_blank"
-            className={cx(Typo.Label.l4_regular_title, BreakLineStyle, LinkStyle)}
-          >
-            <Tooltip title={i18n.t('dovetail.default_http_protocol_tooltip')}>
-              <span
-                className={DashedUnderlineSpanStyle}
-                style={showDashedUnderline ? undefined : { borderBottom: 'none' }}
-              >
-                {clusterVip}:{p.nodePort}
-              </span>
-            </Tooltip>
-          </Link>
-        ));
-      return <ul>{content}</ul>;
+      if (content && content instanceof Array) {
+        content = (
+          <ul className={BreakLineListStyle}>
+            {content.map((item, index) => (
+              <li key={`nodeport-${index}`} className={BreakLineItemStyle}>
+                {item}
+              </li>
+            ))}
+          </ul>
+        );
+      }
+      break;
     case ServiceTypeEnum.ExternalName:
       if (showCopyButton) {
         content = renderAccessItems(


### PR DESCRIPTION
## jira ticket

无

## 问题描述

Service 列表中即使传入 `showCopyButton`，NodePort 类型的集群外访问地址也不会展示复制按钮。

## 问题定位

`ServiceOutClusterAccessComponent` 的 NodePort 渲染逻辑只在 `breakLine=false` 时处理 `showCopyButton`。列表场景默认 `breakLine=true`，会走另一套只渲染链接的分支，因此复制按钮没有展示。

## 代码实现

1. 将 NodePort 地址渲染合并为一套逻辑，先生成地址链接节点，再按 `breakLine` 决定逗号分隔或换行展示。
2. `showCopyButton=true` 时统一使用 `ServiceAccessAddress` 包裹地址链接和复制按钮，列表与详情表现保持一致。
3. 过滤 NodePort 地址时保留 `nodePort` 判断，避免没有外部端口的条目生成无效链接。

## 自测结果

<img width="229" height="474" alt="截屏2026-06-24 15 44 29" src="https://github.com/user-attachments/assets/c38ab576-cadf-4593-97dc-400e6bfc0020" />


## 建议 Review 要点

* 重点关注 `ServiceOutClusterAccessComponent` 中 NodePort 的 `breakLine` 与 `showCopyButton` 组合行为。
* 确认详情页原有逗号分隔与复制按钮展示不回退。

## 建议测试范围

* Service 列表页 NodePort 集群外访问方式展示。
* Service 详情页 NodePort、ExternalName、LoadBalancer 集群外访问方式展示。