### PR TITLE
fix: do not fill create form with cached record

### DIFF
--- a/packages/refine/__tests__/hooks/useReactHookForm.spec.ts
+++ b/packages/refine/__tests__/hooks/useReactHookForm.spec.ts
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useForm } from '../../src/components/Form/useReactHookForm';
+
+const queryResult = {
+  data: {
+    data: {
+      id: 'default/source-pvc',
+      apiVersion: 'v1',
+      kind: 'PersistentVolumeClaim',
+      metadata: { name: 'source-pvc', namespace: 'default' },
+    },
+  },
+};
+
+jest.mock('@refinedev/core', () => {
+  const actual = jest.requireActual('@refinedev/core');
+
+  return {
+    ...actual,
+    useForm: () => ({
+      queryResult,
+      onFinish: jest.fn(),
+      onFinishAutoSave: jest.fn(),
+      formLoading: false,
+      mutationResult: {},
+    }),
+    useTranslate: () => (key: string) => key,
+    useRefineContext: () => ({ options: {} }),
+    useWarnAboutChange: () => ({
+      warnWhenUnsavedChanges: false,
+      setWarnWhen: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('src/hooks/use409Retry', () => ({
+  use409Retry: () => ({
+    captureInitialResource: jest.fn(),
+    mutationMeta: {},
+  }),
+}));
+
+function renderForm(action: 'create' | 'edit') {
+  return renderHook(() =>
+    useForm({
+      refineCoreProps: { resource: 'persistentvolumeclaims', action },
+      defaultValues: {
+        metadata: { name: '', namespace: 'default' },
+      },
+    })
+  );
+}
+
+describe('useReactHookForm initial data', () => {
+  // 详情页打开的新建表单会命中详情页的资源缓存，此时不能用缓存里的资源回填表单
+  it('should not fill the form with the cached record in create action', () => {
+    const { result } = renderForm('create');
+
+    expect(result.current.getValues().metadata.name).toBe('');
+  });
+
+  it('should fill the form with the fetched record in edit action', () => {
+    const { result } = renderForm('edit');
+
+    expect(result.current.getValues().metadata.name).toBe('source-pvc');
+  });
+});

--- a/packages/refine/jest.config.js
+++ b/packages/refine/jest.config.js
@@ -7,6 +7,13 @@ export default {
           throws: false,
           exclude: ['**'],
         },
+        /**
+         * the bundler handles the cjs interop of default imports like `lodash/has`,
+         * ts-jest needs esModuleInterop to do the same when it emits commonjs
+         */
+        tsconfig: {
+          esModuleInterop: true,
+        },
       },
     ],
   },

--- a/packages/refine/package.json
+++ b/packages/refine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-v2/refine",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "module",
   "files": [
     "dist",

--- a/packages/refine/src/components/Form/useReactHookForm.tsx
+++ b/packages/refine/src/components/Form/useReactHookForm.tsx
@@ -236,6 +236,14 @@ export const useForm = <
   useEffect(() => {
     if (hasAppliedInitialDataRef.current || formState.isDirty) return;
 
+    /**
+     * a create form must never be filled with an existing record.
+     * refine falls back to the id in the route when the form resource matches the route
+     * resource, so a create form opened from a detail page builds the same query key as
+     * that page and gets its cached record back, even though the query itself is disabled.
+     */
+    if (refineCoreProps?.action === 'create') return;
+
     const data = queryResult?.data?.data;
     if (!data) return;
 
@@ -265,7 +273,14 @@ export const useForm = <
     });
     hasAppliedInitialDataRef.current = true;
     setTransformedInitValues(getValues());
-  }, [queryResult?.data, setValue, transformInitValues, formState.isDirty, getValues]);
+  }, [
+    queryResult?.data,
+    setValue,
+    transformInitValues,
+    formState.isDirty,
+    getValues,
+    refineCoreProps?.action,
+  ]);
 
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## 问题

从详情页打开的新建表单，会被该详情页的资源数据填满。

对应 [SKS-4805](http://jira.smartx.com/browse/SKS-4805)：在持久卷申领详情页点击「克隆」，弹出的新建表单里名称被默认填成了源持久卷申领的名称；同一个表单从列表页打开则是空的，符合预期。

## 根因

1. `useOpenForm` 没有传 `id`，所以 `useRefineForm` 得到的是 `action: 'create'`、`id: undefined`。
2. refine 的 `useResourceParams` 在「表单 resource 与路由 resource 相同」时会回退到路由上的 id —— `u = i ? (props.id ?? routeId) : props.id`。于是在详情页上，这个表单凭空多出一个它从未申请过的 id。
3. 由此产生的 `useOne` 虽然是禁用的（`enabled: !isCreate && ...`），但 `enabled` 只阻止发请求，不阻止读缓存。此时它的 query key 与详情页 `useShow` 已经写入缓存的那条完全一致，`queryResult.data.data` 会同步拿到源资源。
4. `useReactHookForm` 里回填初始数据的 effect 只判断 data 是否存在，于是把该资源的每个字段都写进了表单。

在列表页，第 2 步拿不到 id，query key 不同，缓存不命中，effect 在早退处就返回了 —— 这就是该问题只在详情页复现的原因。

## 修复

在 create 模式下跳过回填初始数据的 effect：新建表单不应该被任何已有资源填充。`useYamlForm` 早就是这么做的（使用 `queryResult.data.data` 前先判断 `action === 'edit'`），所以同一个表单的 YAML 模式从来没有这个问题。

行为变化只发生在三个条件同时成立时：create 模式 + 路由上有 id + 表单 resource 与路由 resource 相同。其余场景下 `queryResult.data` 本来就是 `undefined`，effect 早已提前返回，加不加守卫没有区别 —— 包括 `setTransformedInitValues`，那个早退同样跳过了它。

## 附带说明

`jest.config.js`：仓库根 tsconfig 是 `esModuleInterop: false`，`lodash/has` 这类默认导入的 cjs interop 由打包器处理；但 ts-jest 产出的是 commonjs，`has_1.default` 会是 undefined，测试一旦执行到该 effect 就会抛错。因此只给 ts-jest 开启了 `esModuleInterop`。这是既有问题，只是此前没有测试会执行到那段代码。

分支上另有一个 `release: 0.4.6` 提交，把 `packages/refine` 的版本号从 0.4.5 提到 0.4.6。

## 测试

- [x] `pnpm unit-test` —— 9 个 suite / 27 条用例通过，含新增的 `__tests__/hooks/useReactHookForm.spec.ts`（create 不从缓存资源回填、edit 仍从请求结果回填）。已验证去掉守卫后该用例会失败。
- [x] `eslint src/components/Form/useReactHookForm.tsx` —— 只剩一条既有的、位于无关 effect 上的 `exhaustive-deps` 警告。
- [x] `pnpm build`
- [x] 通过 yalc 在 sks-ui 侧做集成验证：持久卷申领详情页 → 克隆 → 名称为空；列表页 → 克隆 → 仍为空；提交后 `spec.dataSource` 正确。
