### PR TITLE
fix: show error when submitting multi-document yaml

### DIFF
--- a/packages/refine/__tests__/hooks/useYamlForm.spec.ts
+++ b/packages/refine/__tests__/hooks/useYamlForm.spec.ts
@@ -1,0 +1,121 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import useYamlForm from '../../src/components/Form/useYamlForm';
+
+const onFinishCore = jest.fn();
+
+jest.mock('@refinedev/core', () => {
+  const actual = jest.requireActual('@refinedev/core');
+
+  return {
+    ...actual,
+    useForm: () => ({
+      queryResult: undefined,
+      onFinish: onFinishCore,
+      formLoading: false,
+      mutationResult: {},
+    }),
+    useResource: () => ({ action: 'create', resource: { name: 'configmaps' } }),
+    useWarnAboutChange: () => ({
+      warnWhenUnsavedChanges: false,
+      setWarnWhen: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('src/hooks/use409Retry', () => ({
+  use409Retry: () => ({
+    captureInitialResource: jest.fn(),
+    mutationMeta: {},
+  }),
+}));
+
+jest.mock('src/hooks/useSchema', () => ({
+  useSchema: () => ({
+    schema: null,
+    loading: false,
+    error: null,
+    fetchSchema: jest.fn(),
+  }),
+}));
+
+jest.mock('src/hooks/useGlobalStore', () => ({
+  useGlobalStore: () => ({ restoreItem: (item: unknown) => item }),
+}));
+
+jest.mock('src/hooks/useK8sYamlEditor', () => ({
+  __esModule: true,
+  default: () => ({ fold: jest.fn() }),
+}));
+
+const SINGLE_DOCUMENT_YAML = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo
+`;
+
+const MULTI_DOCUMENT_YAML = `${SINGLE_DOCUMENT_YAML}---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bar
+`;
+
+function renderYamlForm(editorValue: string) {
+  const onSubmitAbort = jest.fn();
+  const { result } = renderHook(() =>
+    useYamlForm({
+      resource: 'configmaps',
+      action: 'create',
+      // RefineFormContainer 切换到 YAML 模式时总会传入数组，即使没有任何字段需要校验
+      rules: [],
+      onSubmitAbort,
+    })
+  );
+
+  // editorProps.ref 就是 hook 内部读取编辑器内容的 ref，测试里直接注入桩实现
+  (
+    result.current.editorProps.ref as unknown as {
+      current: { getEditorValue: () => string };
+    }
+  ).current = { getEditorValue: () => editorValue };
+
+  return { result, onSubmitAbort };
+}
+
+describe('useYamlForm submit', () => {
+  beforeEach(() => {
+    onFinishCore.mockClear();
+  });
+
+  // 多文档 YAML 在编辑器里语法合法，但 js-yaml 的单文档 load 会抛错，
+  // 该异常必须被捕获并转成提示，否则用户点击提交毫无反应
+  it('should show the single document error when submitting multi-document yaml', async () => {
+    const { result, onSubmitAbort } = renderYamlForm(MULTI_DOCUMENT_YAML);
+
+    await act(async () => {
+      await result.current.formProps.onFinish?.({});
+    });
+
+    expect(result.current.editorProps.errorMsgs).toEqual([
+      'dovetail.only_support_one_yaml',
+    ]);
+    expect(onSubmitAbort).toHaveBeenCalled();
+    expect(onFinishCore).not.toHaveBeenCalled();
+  });
+
+  it('should submit single document yaml', async () => {
+    const { result, onSubmitAbort } = renderYamlForm(SINGLE_DOCUMENT_YAML);
+
+    await act(async () => {
+      await result.current.formProps.onFinish?.({});
+    });
+
+    expect(result.current.editorProps.errorMsgs).toEqual([]);
+    expect(onSubmitAbort).not.toHaveBeenCalled();
+    expect(onFinishCore).toHaveBeenCalledWith({
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { name: 'foo' },
+    });
+  });
+});

--- a/packages/refine/src/components/Form/useYamlForm.ts
+++ b/packages/refine/src/components/Form/useYamlForm.ts
@@ -402,15 +402,16 @@ const useYamlForm = <
           return;
         }
 
-        const rulesErrors = await validateRules(editor.current?.getEditorValue() || '');
-
-        if (Object.keys(rulesErrors).length) {
-          onSubmitAbort?.();
-          setRulesErrors(Object.values(rulesErrors));
-          return;
-        }
-
         try {
+          // validateRules 内部同样会解析 YAML，多文档等解析异常需要落到下方 catch 才能转成用户可读提示
+          const rulesErrors = await validateRules(editor.current?.getEditorValue() || '');
+
+          if (Object.keys(rulesErrors).length) {
+            onSubmitAbort?.();
+            setRulesErrors(Object.values(rulesErrors));
+            return;
+          }
+
           const objectValues = editor.current
             ? (yaml.load(editor.current?.getEditorValue() || '') as Unstructured)
             : values;
@@ -452,6 +453,8 @@ const useYamlForm = <
           return onFinish(finalValues as TVariables);
         } catch (error: unknown) {
           onSubmitAbort?.();
+          // validateRules 抛出时不会写入 rulesErrors，清空避免上一次提交的规则错误残留
+          setRulesErrors([]);
           if (error instanceof Error) {
             if (
               error.message === 'expected a single document in the stream, but found more'


### PR DESCRIPTION
## 问题

在 YAML 编辑器中填写多个 `---` 分隔的文档后点击提交，界面**没有任何反应**：弹窗不关闭、不报错、按钮也不进入 loading 状态。

## 根因

`useYamlForm` 的 `onFinish` 中，`validateRules` 的调用在 `try` 块**之外**。

monaco-yaml 的 Kubernetes 模式允许多文档 YAML，因此 `isYamlValid` / `isSchemaValid` 均为 `true`，校验放行；随后 `validateRules` 内部用 js-yaml 的单文档 `yaml.load()` 解析，抛出 `expected a single document in the stream, but found more`。该异常逃出 `onFinish`，被 `YamlForm.tsx` 的空 `catch {}` 静默吞掉。

而 `catch` 块里其实**已经写好了**针对这个错误的处理，会提示 `dovetail.only_support_one_yaml`（「一次仅支持输入一个 YAML 配置。」），只是覆盖不到 `validateRules` 这次调用。

## 改动

- 将 `validateRules` 的调用移入既有的 `try` 块，让已有的错误处理生效
- catch 中补 `setRulesErrors([])`：`validateRules` 抛错时不会写入 rulesErrors，需清空避免上次提交的规则错误残留，与上方 YAML 语法错误分支的处理保持对称
- 新增 `__tests__/hooks/useYamlForm.spec.ts`，覆盖多文档提交给出提示并中止、单文档提交正常走通两条路径

## 测试

- [x] 新增用例通过，且**回退修复后多文档用例确实失败**，确认测试能捕获该 bug
- [x] 全量单测 29 passed（原 27 + 新增 2）
- [x] `pnpm lint` 0 error
- [x] `pnpm build`（vite + tsc）通过